### PR TITLE
Scale the Player_figure according to the world_scale

### DIFF
--- a/addons/vr-common/functions/Function_Teleport.gd
+++ b/addons/vr-common/functions/Function_Teleport.gd
@@ -69,6 +69,7 @@ func _ready():
 	# Scale to our world scale
 	$Teleport.mesh.size = Vector2(0.05 * ws, 1.0)
 	$Target.mesh.size = Vector2(ws, ws)
+	$Target/Player_figure.scale = Vector3(ws, ws, ws)
 	
 	# create shape object
 	collision_shape = CapsuleShape.new()
@@ -88,6 +89,7 @@ func _physics_process(delta):
 		ws = new_ws
 		$Teleport.mesh.size = Vector2(0.05 * ws, 1.0)
 		$Target.mesh.size = Vector2(ws, ws)
+		$Target/Player_figure.scale = Vector3(ws, ws, ws)
 	
 	# button 15 is mapped to our trigger
 	if controller and controller.get_is_active() and controller.is_button_pressed(15):


### PR DESCRIPTION
When altering the `world_scale`, the Player_figure size does not change accordingly. This patch allows to specify the player's height intuitively in gameworld units, and not in physical units.