### PR TITLE
Making improvements to the direct movement function

### DIFF
--- a/addons/vr-common/functions/Function_Direct_movement.tscn
+++ b/addons/vr-common/functions/Function_Direct_movement.tscn
@@ -3,22 +3,22 @@
 [ext_resource path="res://addons/vr-common/functions/Function_Direct_movement.gd" type="Script" id=1]
 
 [sub_resource type="CapsuleShape" id=1]
-
 radius = 0.3
 height = 1.2
 
-[node name="Function_Direct_movement" type="Spatial"]
+[node name="Function_Direct_movement" type="Node"]
 script = ExtResource( 1 )
 max_speed = 500.0
 
 [node name="KinematicBody" type="KinematicBody" parent="."]
+collision_mask = 1048574
 
 [node name="CollisionShape" type="CollisionShape" parent="KinematicBody"]
-transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0.9, 0 )
+transform = Transform( 1, 0, 0, 0, -4.37114e-008, -1, 0, 1, -4.37114e-008, 0, 0.9, 0 )
 shape = SubResource( 1 )
 
 [node name="Tail" type="RayCast" parent="KinematicBody"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0 )
 enabled = true
 cast_to = Vector3( 0, -0.6, 0 )
-
+collision_mask = 1048575


### PR DESCRIPTION
I'm making a few changes to the direct movement function here.

The root node is now of type Node. This breaks the parent<->child change for our positioning. Before when you moved your controller you would also be moving our kinematic body seeing it was a child causing issues in the physics engine. Now our kinematic bodies movement is fully controlled by us which allows us to correctly place it where the player is and then test where the player moves to.

I've removed the height setting, instead we change the height of our collision shape based on the vertical position of our headset in relation to our origin point. This means the collision shape will approximate the height of our actual player and adjust itself if the player crouches. 

Finally I've removed the origin node export variable and am just selecting the origin node directly as it has to be the parent of the parent mode.
Also if you do not specify a camera it will attempt to find our camera node.