### PR TITLE
Use is_instance_valid to check if targets are still valid

### DIFF
--- a/addons/vr-common/functions/Function_pointer.gd
+++ b/addons/vr-common/functions/Function_pointer.gd
@@ -101,7 +101,7 @@ func _process(delta):
 	if enabled and $Laser/RayCast.is_colliding():
 		var new_at = $Laser/RayCast.get_collision_point()
 		
-		if target:
+		if is_instance_valid(target):
 			# if target is set our mouse must be down, we keep "focus" on our target
 			if new_at != last_collided_at:
 				emit_signal("pointer_moved", target, last_collided_at, new_at)
@@ -114,14 +114,14 @@ func _process(delta):
 			# are we pointing to a new target?
 			if new_target != last_target:
 				# exit the old
-				if last_target:
+				if is_instance_valid(last_target):
 					emit_signal("pointer_exited", last_target)
 					
 					if ducktyped_body and last_target.has_method("pointer_exited"):
 						last_target.pointer_exited()
 				
 				# enter the new
-				if new_target:
+				if is_instance_valid(new_target):
 					emit_signal("pointer_entered", new_target)
 					
 					if ducktyped_body and new_target.has_method("pointer_entered"):
@@ -137,7 +137,7 @@ func _process(delta):
 		
 		# remember our new position
 		last_collided_at = new_at
-	elif last_target:
+	elif is_instance_valid(last_target):
 		emit_signal("pointer_exited", last_target)
 		
 		if ducktyped_body and last_target.has_method("pointer_exited"):


### PR DESCRIPTION
I experienced an error with Function_pointer.gd: After changing scenes based on a button on a 2din3d viewport UI being pressed (this viewport being part of the scene that was changed), the target variable was an already freed instance. Just doing a "if target" test is apparently insufficient to determine if the node was still there but replacing it with an is_instance_valid test fixed the issue.