### PR TITLE
Add reset transform on pickup flag

### DIFF
--- a/addons/vr-common/VERSIONS.md
+++ b/addons/vr-common/VERSIONS.md
@@ -1,6 +1,7 @@
 1.3 (in progress)
 =================
 - Add enums to our export variables
+- Add a switch on pickable objects to keep their current positioning when picked up.
 
 1.2
 ===

--- a/addons/vr-common/objects/Object_pickable.gd
+++ b/addons/vr-common/objects/Object_pickable.gd
@@ -2,6 +2,7 @@ extends RigidBody
 
 # Set hold mode
 export (bool) var press_to_hold = true
+export (bool) var reset_transform_on_pickup = true
 export  (int, FLAGS, "Layer 1", "Layer 2", "Layer 3", "Layer 4", "Layer 5", "Layer 6", "Layer 7", "Layer 8", "Layer 9", "Layer 10", "Layer 11", "Layer 12", "Layer 13", "Layer 14", "Layer 15", "Layer 16", "Layer 17", "Layer 18", "Layer 19", "Layer 20") var picked_up_layer = 0
 
 # Remember some state so we can return to it when the user drops the object
@@ -57,11 +58,16 @@ func pick_up(by, with_controller):
 	collision_mask = 0
 	
 	# now reparent it
+	var original_transform = global_transform
 	original_parent.remove_child(self)
 	picked_up_by.add_child(self)
 	
-	# reset our transform
-	transform = Transform()
+	if reset_transform_on_pickup:
+		# reset our transform
+		transform = Transform()
+	else:
+		# make sure we keep its original position
+		global_transform = original_transform
 
 # we are being let go
 func let_go(starting_linear_velocity = Vector3(0.0, 0.0, 0.0)):


### PR DESCRIPTION
Add a flag on pickable object so we can retain the relative position to the controller when picked up.

Note, if the flag is set to true, the behavior is as current, the transform is reset and the object snaps to the controller.
If the flag is set to false the relative position with the controller is retained. 