### PR TITLE
Implemented smooth turning and moved collisionshape backwards

### DIFF
--- a/addons/vr-common/VERSIONS.md
+++ b/addons/vr-common/VERSIONS.md
@@ -4,6 +4,8 @@
 - Add a switch on pickable objects to keep their current positioning when picked up
 - Move direct movement player collision slightly backwards based on player radius
 - Added switch between step turning and smooth turning
+- Fixed sizing issue with teleport
+- Added option to change pickup range
 
 1.2
 ===

--- a/addons/vr-common/VERSIONS.md
+++ b/addons/vr-common/VERSIONS.md
@@ -1,7 +1,9 @@
 1.3 (in progress)
 =================
 - Add enums to our export variables
-- Add a switch on pickable objects to keep their current positioning when picked up.
+- Add a switch on pickable objects to keep their current positioning when picked up
+- Move direct movement player collision slightly backwards based on player radius
+- Added switch between step turning and smooth turning
 
 1.2
 ===

--- a/addons/vr-common/functions/Function_Pickup.gd
+++ b/addons/vr-common/functions/Function_Pickup.gd
@@ -22,6 +22,7 @@ enum Buttons {
 	VR_TRIGGER = 15
 }
 
+export var pickup_range = 0.5 setget set_pickup_range
 export var impulse_factor = 1.0
 export (Buttons) var pickup_button_id = Buttons.VR_GRIP
 export (Buttons) var action_button_id = Buttons.VR_TRIGGER
@@ -33,6 +34,11 @@ var picked_up_object = null
 
 var last_position = Vector3(0.0, 0.0, 0.0)
 var velocities = Array()
+
+func set_pickup_range(new_range):
+	pickup_range = new_range
+	if $CollisionShape:
+		$CollisionShape.shape.radius = pickup_range
 
 func _get_velocity():
 	var velocity = Vector3(0.0, 0.0, 0.0)
@@ -46,16 +52,16 @@ func _get_velocity():
 	
 	return velocity
 
-func _on_Function_Pickup_body_entered(body):
+func _on_Function_Pickup_entered(object):
 	# add our object to our array if required
-	if body.has_method('pick_up') and object_in_area.find(body) == -1:
-		object_in_area.push_back(body)
+	if object.has_method('pick_up') and object_in_area.find(object) == -1:
+		object_in_area.push_back(object)
 		_update_closest_object()
 
-func _on_Function_Pickup_body_exited(body):
+func _on_Function_Pickup_exited(object):
 	# remove our object from our array
-	if object_in_area.find(body) != -1:
-		object_in_area.erase(body)
+	if object_in_area.find(object) != -1:
+		object_in_area.erase(object)
 		_update_closest_object()
 
 func _update_closest_object():
@@ -122,6 +128,9 @@ func _ready():
 	get_parent().connect("button_pressed", self, "_on_button_pressed")
 	get_parent().connect("button_release", self, "_on_button_release")
 	last_position = global_transform.origin
+	
+	# re-assign now that our collision shape has been constructed
+	set_pickup_range(pickup_range)
 
 func _process(delta):
 	velocities.push_back((global_transform.origin - last_position) / delta)
@@ -130,3 +139,4 @@ func _process(delta):
 	
 	last_position = global_transform.origin
 	_update_closest_object()
+

--- a/addons/vr-common/functions/Function_Pickup.tscn
+++ b/addons/vr-common/functions/Function_Pickup.tscn
@@ -11,5 +11,7 @@ script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
 shape = SubResource( 1 )
-[connection signal="body_entered" from="." to="." method="_on_Function_Pickup_body_entered"]
-[connection signal="body_exited" from="." to="." method="_on_Function_Pickup_body_exited"]
+[connection signal="area_entered" from="." to="." method="_on_Function_Pickup_entered"]
+[connection signal="area_exited" from="." to="." method="_on_Function_Pickup_exited"]
+[connection signal="body_entered" from="." to="." method="_on_Function_Pickup_entered"]
+[connection signal="body_exited" from="." to="." method="_on_Function_Pickup_exited"]

--- a/addons/vr-common/functions/Function_Teleport.gd
+++ b/addons/vr-common/functions/Function_Teleport.gd
@@ -75,12 +75,11 @@ func set_player_height(p_height):
 	player_height = p_height
 	
 	if collision_shape:
-		# for some reason collision shape height measurement is half up, half down from center 
-		collision_shape.height = (player_height / 2.0) + 0.1
+		collision_shape.height = player_height - (2.0 * player_radius)
 		
-		if capsule:
-			capsule.mesh.mid_height = player_height - (2.0 * player_radius)
-			capsule.translation = Vector3(0.0, player_height/2.0, 0.0)
+	if capsule:
+		capsule.mesh.mid_height = player_height - (2.0 * player_radius)
+		capsule.translation = Vector3(0.0, player_height/2.0, 0.0)
 
 func get_player_radius():
 	return player_radius
@@ -89,11 +88,12 @@ func set_player_radius(p_radius):
 	player_radius = p_radius
 	
 	if collision_shape:
+		collision_shape.height = player_height - (2.0 * player_radius)
 		collision_shape.radius = player_radius
-
-		if capsule:
-			capsule.mesh.mid_height = player_height - (2.0 * player_radius)
-			capsule.mesh.radius = player_radius
+	
+	if capsule:
+		capsule.mesh.mid_height = player_height - (2.0 * player_radius)
+		capsule.mesh.radius = player_radius
 
 func _ready():
 	# We should be a child of an ARVRController and it should be a child or our ARVROrigin


### PR DESCRIPTION
Added some logic to the direct movement script so our collision shape is moved a bit backwards. You couldn't get close up to a wall because the collision shape was centered on the camera (eyes) which really are at the front of the player. We thus move the collision shape back by the radius of the player.

I've also added an option to enable smooth turning