### PR TITLE
Fix incorrect signal hookup in SnapZone (_on_snap_zone_body_entered)

### DIFF
--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -73,7 +73,7 @@ func _ready():
 
 	# Add important connections
 	if not body_entered.is_connected(_on_snap_zone_body_entered):
-		body_entered.connect(_on_snap_zone_body_exited)
+		body_entered.connect(_on_snap_zone_body_entered)
 	if not body_exited.is_connected(_on_snap_zone_body_exited):
 		body_exited.connect(_on_snap_zone_body_exited)
 


### PR DESCRIPTION
This was a simple fix to fix up what was probably just a quick copy and paste, honest mistake. I was screaming at my laptop until I took a peek at the code to debug and it was obvious. :P 