### PR TITLE
Use correct up direction in player movement

### DIFF
--- a/addons/godot-xr-tools/player/player_body.gd
+++ b/addons/godot-xr-tools/player/player_body.gd
@@ -399,7 +399,7 @@ func request_jump(skip_jump_velocity := false):
 func move_player(p_velocity: Vector3) -> Vector3:
 	velocity = p_velocity
 	max_slides = 4
-	up_direction = ground_vector
+	up_direction = up_gravity
 
 	# Get the player body location before we apply our movement.
 	var transform_before_movement : Transform3D = global_transform


### PR DESCRIPTION
When the player walks up a slope, it gets with launched into the air with enough speed. This occurs because the `move_body` function sets the `up_direction` to the `ground_vector`, where this is the surface normal. That leads to incorrect physics calculation.

The proposed change is to use the gravity-based up direction (`up_gravity`) instead.

