### PR TITLE
Support using Grip and Palm pose for hands

### DIFF
--- a/.gdlintrc
+++ b/.gdlintrc
@@ -1,0 +1,1 @@
+max-line-length: 200

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 *.tres eol=lf
 *.import eol=lf
 *.gdshader eol=lf
+*.uid eol=lf

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -8,6 +8,7 @@
 - Fix grab with scaled pickables by swapping inverse for affine_inverse
 - Fix "UP" direction in player movement
 - Gracefully handle freed objects with collision exceptions
+- Added support for using grip or palm pose instead of aim pose
 
 # 4.4.0
 - Minimum Godot version changed to 4.2

--- a/addons/godot-xr-tools/desktop-support/mouse_capture.gd
+++ b/addons/godot-xr-tools/desktop-support/mouse_capture.gd
@@ -48,4 +48,3 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 	elif (!xr_start_node.is_xr_active() and capture):
 		Input.mouse_mode=Input.MOUSE_MODE_CAPTURED
 	return
-

--- a/addons/godot-xr-tools/desktop-support/mouse_capture.tscn
+++ b/addons/godot-xr-tools/desktop-support/mouse_capture.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://71ls6bjad8tp" path="res://addons/godot-xr-tools/desktop-support/mouse_capture.gd" id="1_po4v8"]
 
-[node name="MouseCapture" type="Node" groups=["movement_providers"]]
+[node name="MouseCapture" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1_po4v8")

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.gd
@@ -81,4 +81,3 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 			player_body.override_player_height(self, crouch_height)
 		else:
 			player_body.override_player_height(self)
-

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.tscn
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://onavg33r434i" path="res://addons/godot-xr-tools/desktop-support/movement_desktop_crouch.gd" id="1_4rbnc"]
 
-[node name="MovementDesktopCrouch" type="Node" groups=["movement_providers"]]
+[node name="MovementDesktopCrouch" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1_4rbnc")

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_direct.tscn
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_direct.tscn
@@ -2,6 +2,5 @@
 
 [ext_resource type="Script" uid="uid://ciqexxqb7lxs4" path="res://addons/godot-xr-tools/desktop-support/movement_desktop_direct.gd" id="1_e8v0q"]
 
-[node name="MovementDesktopDirect" type="Node" groups=["movement_providers"]]
+[node name="MovementDesktopDirect" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1_e8v0q")
-strafe = true

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_flight.tscn
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_flight.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://te6vlh1cbi7o" path="res://addons/godot-xr-tools/desktop-support/movement_desktop_flight.gd" id="1_exmlf"]
 
-[node name="MovementDesktopFlight" type="Node" groups=["movement_providers"]]
+[node name="MovementDesktopFlight" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1_exmlf")

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_jump.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_jump.gd
@@ -41,4 +41,3 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 	# Request jump if the button is pressed
 	if Input.is_action_pressed(jump_button_action):
 		player_body.request_jump()
-

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_jump.tscn
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_jump.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://b0l4n05yrf11b" path="res://addons/godot-xr-tools/desktop-support/movement_desktop_jump.gd" id="1_tccpc"]
 
-[node name="MovementDesktopJump" type="Node" groups=["movement_providers"]]
+[node name="MovementDesktopJump" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1_tccpc")

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_sprint.tscn
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_sprint.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://dskqlyywoylkm" path="res://addons/godot-xr-tools/desktop-support/movement_desktop_sprint.gd" id="1_md0f7"]
 
-[node name="MovementDesktopSprint" type="Node" groups=["movement_providers"]]
+[node name="MovementDesktopSprint" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1_md0f7")

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_turn.tscn
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_turn.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://bjqk58f7j3hgl" path="res://addons/godot-xr-tools/desktop-support/movement_desktop_turn.gd" id="1_qv43c"]
 
-[node name="MovementDesktopTurn" type="Node" groups=["movement_providers"]]
+[node name="MovementDesktopTurn" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1_qv43c")

--- a/addons/godot-xr-tools/desktop-support/movement_gravity_zones.tscn
+++ b/addons/godot-xr-tools/desktop-support/movement_gravity_zones.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://dyifp672tjli7" path="res://addons/godot-xr-tools/desktop-support/movement_gravity_zones.gd" id="1"]
 
-[node name="MovementGravityZones" type="Node" groups=["movement_providers"]]
+[node name="MovementGravityZones" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")

--- a/addons/godot-xr-tools/functions/function_pose_detector.gd
+++ b/addons/godot-xr-tools/functions/function_pose_detector.gd
@@ -1,7 +1,7 @@
 @tool
 @icon("res://addons/godot-xr-tools/editor/icons/hand.svg")
 class_name XRToolsFunctionPoseDetector
-extends Node3D
+extends XRToolsHandPalmOffset
 
 
 ## XR Tools Function Pose Area
@@ -18,11 +18,8 @@ const DEFAULT_MASK := 0b0000_0000_0010_0000_0000_0000_0000_0000
 @export_flags_3d_physics var collision_mask : int = DEFAULT_MASK: set = set_collision_mask
 
 
-## Hand controller
-@onready var _controller := XRHelpers.get_xr_controller(self)
-
 ## Hand to control
-@onready var _hand := XRToolsHand.find_instance(self)
+var _hand : XRToolsHand
 
 
 # Add support for is_xr_class on XRTools classes
@@ -30,8 +27,12 @@ func is_xr_class(name : String) -> bool:
 	return name == "XRToolsFunctionPoseDetector"
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
+# Called when we enter our tree
+func _enter_tree():
+	super._enter_tree()
+
+	_hand = XRToolsHand.find_instance(self)
+
 	# Connect signals (if controller and hand are valid)
 	if _controller and _hand:
 		if $SenseArea.area_entered.connect(_on_area_entered):
@@ -43,12 +44,19 @@ func _ready():
 	_update_collision_mask()
 
 
+func _exit_tree():
+	# Disconnect signals (if controller and hand are valid)
+	if _controller and _hand:
+		$SenseArea.area_entered.disconnect(_on_area_entered)
+		$SenseArea.area_exited.disconnect(_on_area_exited)
+
+	_hand = null
+	super._exit_tree()
+
+
 # This method verifies the pose area has a valid configuration.
 func _get_configuration_warnings() -> PackedStringArray:
-	var warnings := PackedStringArray()
-
-	if !XRHelpers.get_xr_controller(self):
-		warnings.append("Node must be within a branch of an XRController3D node")
+	var warnings : PackedStringArray = super._get_configuration_warnings()
 
 	# Verify hand can be found
 	if !XRToolsHand.find_instance(self):

--- a/addons/godot-xr-tools/functions/function_pose_detector.tscn
+++ b/addons/godot-xr-tools/functions/function_pose_detector.tscn
@@ -15,5 +15,5 @@ collision_mask = 2097152
 monitorable = false
 
 [node name="CollisionShape" type="CollisionShape3D" parent="SenseArea"]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, -0.04, 0.08)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.01)
 shape = SubResource("1")

--- a/addons/godot-xr-tools/functions/function_teleport.gd
+++ b/addons/godot-xr-tools/functions/function_teleport.gd
@@ -1,7 +1,7 @@
 @tool
 @icon("res://addons/godot-xr-tools/editor/icons/function.svg")
 class_name XRToolsFunctionTeleport
-extends Node3D
+extends XRToolsHandPalmOffset
 
 
 ## XR Tools Function Teleport Script
@@ -106,14 +106,18 @@ var player : Node3D
 ## [XRToolsPlayerBody] node.
 @onready var player_body := XRToolsPlayerBody.find_instance(self)
 
-## [XRController3D] node.
-@onready var controller := XRHelpers.get_xr_controller(self)
-
 
 # Add support for is_xr_class on XRTools classes
 func is_xr_class(name : String) -> bool:
 	return name == "XRToolsFunctionTeleport"
 
+
+func _enter_tree():
+	var bt:= Transform3D()
+	bt.origin = Vector3(0.0, 0.0, -0.1)
+	set_base_transform(bt)
+
+	super._enter_tree()
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -148,7 +152,7 @@ func _physics_process(delta):
 		return
 
 	# Skip if required nodes are missing
-	if !player_body or !controller:
+	if !player_body or !_controller:
 		return
 
 	# if we're not enabled no point in doing mode
@@ -170,8 +174,8 @@ func _physics_process(delta):
 		$Target.mesh.size = Vector2(ws, ws)
 		$Target/Player_figure.scale = Vector3(ws, ws, ws)
 
-	if controller and controller.get_is_active() and \
-			controller.is_button_pressed(teleport_button_action):
+	if _controller and _controller.get_is_active() and \
+			_controller.is_button_pressed(teleport_button_action):
 		if !is_teleporting:
 			is_teleporting = true
 			$Teleport.visible = true
@@ -300,7 +304,7 @@ func _physics_process(delta):
 				color = cant_teleport_color
 
 			# check our axis to see if we need to rotate
-			teleport_rotation += (delta * controller.get_vector2(rotation_action).x * -4.0)
+			teleport_rotation += (delta * _controller.get_vector2(rotation_action).x * -4.0)
 
 			# update target and colour
 			var target_basis := Basis()
@@ -340,15 +344,11 @@ func _physics_process(delta):
 
 # This method verifies the teleport has a valid configuration.
 func _get_configuration_warnings() -> PackedStringArray:
-	var warnings := PackedStringArray()
+	var warnings : PackedStringArray = super._get_configuration_warnings()
 
 	# Verify we can find the XRToolsPlayerBody
 	if !XRToolsPlayerBody.find_instance(self):
 		warnings.append("This node must be within a branch of an XRToolsPlayerBody node")
-
-	# Verify we can find the XRController3D
-	if !XRHelpers.get_xr_controller(self):
-		warnings.append("This node must be within a branch of an XRController3D node")
 
 	# Return warnings
 	return warnings

--- a/addons/godot-xr-tools/functions/movement_climb.tscn
+++ b/addons/godot-xr-tools/functions/movement_climb.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://dtl3uo5dnibof" path="res://addons/godot-xr-tools/functions/movement_climb.gd" id="1"]
 
-[node name="MovementClimb" type="Node" groups=["movement_providers"]]
+[node name="MovementClimb" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")

--- a/addons/godot-xr-tools/functions/movement_crouch.tscn
+++ b/addons/godot-xr-tools/functions/movement_crouch.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://vuhhcx5m67gt" path="res://addons/godot-xr-tools/functions/movement_crouch.gd" id="1"]
 
-[node name="MovementCrouch" type="Node" groups=["movement_providers"]]
+[node name="MovementCrouch" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")

--- a/addons/godot-xr-tools/functions/movement_direct.tscn
+++ b/addons/godot-xr-tools/functions/movement_direct.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://dc4hg8kq5ia5y" path="res://addons/godot-xr-tools/functions/movement_direct.gd" id="1"]
 
-[node name="MovementDirect" type="Node" groups=["movement_providers"]]
+[node name="MovementDirect" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")

--- a/addons/godot-xr-tools/functions/movement_flight.tscn
+++ b/addons/godot-xr-tools/functions/movement_flight.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://vyag4h2e7n0p" path="res://addons/godot-xr-tools/functions/movement_flight.gd" id="1"]
 
-[node name="MovementFlight" type="Node" groups=["movement_providers"]]
+[node name="MovementFlight" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")

--- a/addons/godot-xr-tools/functions/movement_footstep.tscn
+++ b/addons/godot-xr-tools/functions/movement_footstep.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://clpt3lske02eh" path="res://addons/godot-xr-tools/functions/movement_footstep.gd" id="1"]
 
-[node name="MovementFootstep" type="Node" groups=["movement_providers"]]
+[node name="MovementFootstep" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")
 
 [node name="PlayerSettings" type="AudioStreamPlayer3D" parent="."]

--- a/addons/godot-xr-tools/functions/movement_glide.tscn
+++ b/addons/godot-xr-tools/functions/movement_glide.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://5pticrbivdx6" path="res://addons/godot-xr-tools/functions/movement_glide.gd" id="1"]
 
-[node name="MovementGlide" type="Node" groups=["movement_providers"]]
+[node name="MovementGlide" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")

--- a/addons/godot-xr-tools/functions/movement_jog.tscn
+++ b/addons/godot-xr-tools/functions/movement_jog.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://f5tfo4ylkuhc" path="res://addons/godot-xr-tools/functions/movement_jog.gd" id="1_k4cao"]
 
-[node name="MovementJog" type="Node" groups=["movement_providers"]]
+[node name="MovementJog" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1_k4cao")

--- a/addons/godot-xr-tools/functions/movement_jump.tscn
+++ b/addons/godot-xr-tools/functions/movement_jump.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://dur4rs2uhr6cp" path="res://addons/godot-xr-tools/functions/movement_jump.gd" id="1"]
 
-[node name="MovementJump" type="Node" groups=["movement_providers"]]
+[node name="MovementJump" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")

--- a/addons/godot-xr-tools/functions/movement_physical_jump.tscn
+++ b/addons/godot-xr-tools/functions/movement_physical_jump.tscn
@@ -2,6 +2,5 @@
 
 [ext_resource type="Script" uid="uid://c0podasns5j2h" path="res://addons/godot-xr-tools/functions/movement_physical_jump.gd" id="1"]
 
-[node name="MovementPhysicalJump" type="Node" groups=["movement_providers"]]
+[node name="MovementPhysicalJump" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")
-arms_jump_enable = true

--- a/addons/godot-xr-tools/functions/movement_provider.gd
+++ b/addons/godot-xr-tools/functions/movement_provider.gd
@@ -1,7 +1,7 @@
 @tool
 @icon("res://addons/godot-xr-tools/editor/icons/movement_provider.svg")
 class_name XRToolsMovementProvider
-extends Node
+extends Node3D
 
 
 ## XR Tools Movement Provider base class

--- a/addons/godot-xr-tools/functions/movement_sprint.tscn
+++ b/addons/godot-xr-tools/functions/movement_sprint.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://cm2m0igkq32wy" path="res://addons/godot-xr-tools/functions/movement_sprint.gd" id="1"]
 
-[node name="MovementSprint" type="Node" groups=["movement_providers"]]
+[node name="MovementSprint" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")

--- a/addons/godot-xr-tools/functions/movement_turn.tscn
+++ b/addons/godot-xr-tools/functions/movement_turn.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://kuxqh057vr5y" path="res://addons/godot-xr-tools/functions/movement_turn.gd" id="1"]
 
-[node name="MovementTurn" type="Node" groups=["movement_providers"]]
+[node name="MovementTurn" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")

--- a/addons/godot-xr-tools/functions/movement_wall_walk.tscn
+++ b/addons/godot-xr-tools/functions/movement_wall_walk.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://bv4jc67lcmo75" path="res://addons/godot-xr-tools/functions/movement_wall_walk.gd" id="1"]
 
-[node name="MovementWallWalk" type="Node" groups=["movement_providers"]]
+[node name="MovementWallWalk" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1")

--- a/addons/godot-xr-tools/functions/movement_world_grab.tscn
+++ b/addons/godot-xr-tools/functions/movement_world_grab.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" uid="uid://bgq1jyvtogcll" path="res://addons/godot-xr-tools/functions/movement_world_grab.gd" id="1_0qp8q"]
 
-[node name="MovementWorldGrab" type="Node" groups=["movement_providers"]]
+[node name="MovementWorldGrab" type="Node3D" groups=["movement_providers"]]
 script = ExtResource("1_0qp8q")

--- a/addons/godot-xr-tools/hands/hand_aim_offset.gd
+++ b/addons/godot-xr-tools/hands/hand_aim_offset.gd
@@ -1,0 +1,96 @@
+@tool
+class_name XRToolsHandAimOffset
+extends Node3D
+
+## XRToolsHandAimOffset will automatically adjust its position,
+## to the aim position (within limits).
+
+## Hand offset to apply based on our controller pose
+## You can use auto if you're using the default aim_pose or grip_pose poses.
+@export_enum("auto", "aim", "grip", "palm", "disable") var hand_offset_mode : int = 0:
+	set(value):
+		hand_offset_mode = value
+		notify_property_list_changed()
+		if is_inside_tree():
+			_update_transform()
+
+# Controller
+var _controller : XRController3D
+
+# Keep track of our tracker and pose
+var _controller_tracker_and_pose : String = ""
+
+# Which node are we applying our transform on?
+var _apply_to : Node3D
+
+# Additional transform to apply
+var _base_transform : Transform3D = Transform3D()
+
+## Add support for is_xr_class on XRTools classes
+func is_xr_class(name : String) -> bool:
+	return name == "XRToolsHandAimOffset"
+
+
+## Set the node we apply our transform to
+## Must be set before _enter_tree is called for the first time.
+func set_apply_to(node : Node3D) -> void:
+	_apply_to = node
+
+
+## Set a base transform to apply
+func set_base_transform(base_transform : Transform3D) -> void:
+	_base_transform = base_transform
+	if is_inside_tree():
+		_update_transform()
+
+
+# Called when we're added to the tree
+func _enter_tree():
+	if not _apply_to:
+		_apply_to = self
+
+	_controller = XRHelpers.get_xr_controller(self)
+
+	_update_transform()
+
+
+# Called when we exit the tree
+func _exit_tree():
+	if _controller:
+		_controller = null
+
+
+# Check property config
+func _validate_property(property):
+	if hand_offset_mode != 4 and (property.name == "position" or property.name == "rotation" or property.name == "scale" or property.name == "rotation_edit_mode" or property.name == "rotation_order"):
+		# We control these, don't let the user set them.
+		property.usage = PROPERTY_USAGE_NONE
+
+
+# This method verifies the hand has a valid configuration.
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings := PackedStringArray()
+
+	# Check for XR Controller
+	var controller = XRHelpers.get_xr_controller(self)
+	if not controller:
+		warnings.append("Hand should descent from an XRController3D node")
+
+	return warnings
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(_delta):
+	# If we have a controller, make sure our hand transform is updated when needed.
+	if _controller:
+		var tracker_and_pose = _controller.tracker + "." + _controller.pose
+		if _controller_tracker_and_pose != tracker_and_pose:
+			_controller_tracker_and_pose = tracker_and_pose
+			if hand_offset_mode == 0:
+				_update_transform()
+
+
+# Update our transform so we are positioned on our aim pose
+func _update_transform() -> void:
+	if _apply_to and hand_offset_mode != 4:
+		_apply_to.transform = XRTools.get_aim_offset(hand_offset_mode, _controller) * _base_transform

--- a/addons/godot-xr-tools/hands/hand_aim_offset.gd.uid
+++ b/addons/godot-xr-tools/hands/hand_aim_offset.gd.uid
@@ -1,0 +1,1 @@
+uid://bhjb6f4bslawl

--- a/addons/godot-xr-tools/hands/hand_palm_offset.gd
+++ b/addons/godot-xr-tools/hands/hand_palm_offset.gd
@@ -1,0 +1,100 @@
+@tool
+class_name XRToolsHandPalmOffset
+extends Node3D
+
+## XRToolsHandPalmOffset will automatically adjust its position,
+## to locate the palm of a hand (within limits).
+
+## Hand offset to apply based on our controller pose
+## You can use auto if you're using the default aim_pose or grip_pose poses.
+@export_enum("auto", "aim", "grip", "palm", "disable") var hand_offset_mode : int = 0:
+	set(value):
+		hand_offset_mode = value
+		notify_property_list_changed()
+		if is_inside_tree():
+			_update_transform()
+
+# Controller
+var _controller : XRController3D
+
+# Keep track of our tracker and pose
+var _controller_tracker_and_pose : String = ""
+
+# Which node are we applying our transform on?
+var _apply_to : Node3D
+
+# Additional transform to apply
+var _base_transform : Transform3D = Transform3D()
+
+## Add support for is_xr_class on XRTools classes
+func is_xr_class(name : String) -> bool:
+	return name == "XRToolsHandAimOffset"
+
+
+## Set the node we apply our transform to
+## Must be set before _enter_tree is called for the first time.
+func set_apply_to(node : Node3D) -> void:
+	_apply_to = node
+
+
+## Set a base transform to apply
+func set_base_transform(base_transform : Transform3D) -> void:
+	_base_transform = base_transform
+	if is_inside_tree():
+		_update_transform()
+
+
+# Called when we're added to the tree
+func _enter_tree():
+	if not _apply_to:
+		_apply_to = self
+
+	_controller = XRHelpers.get_xr_controller(self)
+
+	_update_transform()
+
+
+# Called when we exit the tree
+func _exit_tree():
+	if _controller:
+		_controller = null
+
+
+# Check property config
+func _validate_property(property):
+	if hand_offset_mode != 4 and (property.name == "position" or property.name == "rotation" or property.name == "scale" or property.name == "rotation_edit_mode" or property.name == "rotation_order"):
+		# We control these, don't let the user set them.
+		property.usage = PROPERTY_USAGE_NONE
+
+
+# This method verifies the hand has a valid configuration.
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings := PackedStringArray()
+
+	# Check for XR Controller
+	var controller = XRHelpers.get_xr_controller(self)
+	if not controller:
+		warnings.append("Hand should descent from an XRController3D node")
+	elif controller.pose == "aim":
+		# FIXME we don't get a refresh when the pose changes,
+		# so this doesn't clear until a scene is reloaded...
+		warnings.append("The aim pose is no longer suitable for hand position, consider using the grip pose instead")
+
+	return warnings
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(_delta):
+	# If we have a controller, make sure our hand transform is updated when needed.
+	if _controller:
+		var tracker_and_pose = _controller.tracker + "." + _controller.pose
+		if _controller_tracker_and_pose != tracker_and_pose:
+			_controller_tracker_and_pose = tracker_and_pose
+			if hand_offset_mode == 0:
+				_update_transform()
+
+
+# Update our transform so we are positioned on our palm
+func _update_transform() -> void:
+	if _apply_to and hand_offset_mode != 4:
+		_apply_to.transform = XRTools.get_palm_offset(hand_offset_mode, _controller) * _base_transform

--- a/addons/godot-xr-tools/hands/hand_palm_offset.gd.uid
+++ b/addons/godot-xr-tools/hands/hand_palm_offset.gd.uid
@@ -1,0 +1,1 @@
+uid://drbnpanwky1vo

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/left_fullglove_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/left_fullglove_low.tscn
@@ -7,34 +7,34 @@
 [ext_resource type="AnimationNodeBlendTree" uid="uid://dl8yf7ipqotd1" path="res://addons/godot-xr-tools/hands/animations/left/hand_blend_tree.tres" id="5"]
 [ext_resource type="Material" uid="uid://cdb40djkihelq" path="res://addons/godot-xr-tools/hands/materials/cleaning_glove.tres" id="6"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_qtto3"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_cbo75"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_4i0yd"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_4obwe"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_fahbc"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_y7qwp"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_470u2"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_0qsn2"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_fhgyt"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_hwtfy"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_d6sxb"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_ppujx"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_qtto3")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_cbo75")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_4i0yd")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_4obwe")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_fahbc")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_y7qwp")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_470u2")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_0qsn2")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_fhgyt")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_hwtfy")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -44,10 +44,10 @@ hand_blend_tree = ExtResource("5")
 default_pose = ExtResource("3_wyae6")
 
 [node name="Hand_low_L" parent="." instance=ExtResource("2")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.01, 0, 0.05)
 
 [node name="Skeleton3D" parent="Hand_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -73,9 +73,9 @@ surface_material_override/0 = ExtResource("6")
 [node name="AnimationPlayer" parent="Hand_low_L" instance=ExtResource("1")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_d6sxb")
+root_node = NodePath("../Hand_low_L")
+tree_root = SubResource("AnimationNodeBlendTree_ppujx")
 anim_player = NodePath("../Hand_low_L/AnimationPlayer")
-active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
 

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/right_fullglove_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/right_fullglove_low.tscn
@@ -7,34 +7,34 @@
 [ext_resource type="Script" uid="uid://cnwtovj4mqc45" path="res://addons/godot-xr-tools/hands/hand.gd" id="4"]
 [ext_resource type="AnimationNodeBlendTree" uid="uid://m85b1gogdums" path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" id="6"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_sjc0m"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_q2uyk"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_bf0db"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_swmod"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_kdora"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_vq0yy"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_l50hj"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_65tsc"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_vrc3g"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_t1cog"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_ayvqt"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_xdmiy"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_sjc0m")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_q2uyk")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_bf0db")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_swmod")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_kdora")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_vq0yy")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_l50hj")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_65tsc")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_vrc3g")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_t1cog")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -44,10 +44,9 @@ hand_blend_tree = ExtResource("6")
 default_pose = ExtResource("3_r4xyu")
 
 [node name="Hand_low_R" parent="." instance=ExtResource("2")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15)
 
 [node name="Skeleton3D" parent="Hand_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -73,9 +72,9 @@ surface_material_override/0 = ExtResource("3")
 [node name="AnimationPlayer" parent="Hand_low_R" instance=ExtResource("1")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_ayvqt")
+root_node = NodePath("../Hand_low_R")
+tree_root = SubResource("AnimationNodeBlendTree_xdmiy")
 anim_player = NodePath("../Hand_low_R/AnimationPlayer")
-active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
 

--- a/addons/godot-xr-tools/hands/scenes/lowpoly/right_hand_low.tscn
+++ b/addons/godot-xr-tools/hands/scenes/lowpoly/right_hand_low.tscn
@@ -7,34 +7,34 @@
 [ext_resource type="Material" uid="uid://dy6nhifvvmm73" path="res://addons/godot-xr-tools/hands/materials/caucasian_hand.tres" id="4"]
 [ext_resource type="AnimationNodeBlendTree" uid="uid://m85b1gogdums" path="res://addons/godot-xr-tools/hands/animations/right/hand_blend_tree.tres" id="6"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_mbwcx"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_1ao0x"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_dyc5q"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_8pdeq"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_dknar"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ed6h4"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_covtt"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_1ja5n"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_h5uio"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_hspyh"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_7kqgu"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_sse2s"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_mbwcx")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_1ao0x")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_dyc5q")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_8pdeq")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_dknar")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_ed6h4")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_covtt")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_1ja5n")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_h5uio")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_hspyh")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -44,10 +44,10 @@ hand_blend_tree = ExtResource("6")
 default_pose = ExtResource("3_f67ka")
 
 [node name="Hand_Nails_low_R" parent="." instance=ExtResource("2")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.03, -0.05, 0.15)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.01, 0, 0.05)
 
 [node name="Skeleton3D" parent="Hand_Nails_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -73,9 +73,9 @@ surface_material_override/0 = ExtResource("4")
 [node name="AnimationPlayer" parent="Hand_Nails_low_R" instance=ExtResource("1")]
 
 [node name="AnimationTree" type="AnimationTree" parent="."]
-tree_root = SubResource("AnimationNodeBlendTree_7kqgu")
+root_node = NodePath("../Hand_Nails_low_R")
+tree_root = SubResource("AnimationNodeBlendTree_sse2s")
 anim_player = NodePath("../Hand_Nails_low_R/AnimationPlayer")
-active = true
 parameters/Grip/blend_amount = 0.0
 parameters/Trigger/blend_amount = 0.0
 

--- a/addons/godot-xr-tools/misc/xr_helpers.gd
+++ b/addons/godot-xr-tools/misc/xr_helpers.gd
@@ -134,4 +134,3 @@ static func _get_controller(
 
 	# Could not find the controller
 	return null
-

--- a/addons/godot-xr-tools/objects/grab_points/grab.gd
+++ b/addons/godot-xr-tools/objects/grab_points/grab.gd
@@ -63,8 +63,11 @@ func _init(
 	hand_point = p_point as XRToolsGrabPointHand
 
 	# Calculate the grab transform
-	if p_point:
-		transform = p_point.transform
+	if hand_point:
+		# Get our adjusted grab point (palm position)
+		transform = hand_point.get_palm_transform()
+	elif point:
+		transform = point.transform
 	elif p_precise:
 		transform = p_what.global_transform.affine_inverse() * by.global_transform
 	else:
@@ -113,7 +116,8 @@ func set_grab_point(p_point : XRToolsGrabPoint) -> void:
 
 	# Update the transform
 	if point:
-		transform = point.transform
+		# Get our adjusted grab point (palm position)
+		transform = p_point.get_palm_transform()
 
 	# Apply the new hand grab-point settings
 	if hand_point:

--- a/addons/godot-xr-tools/objects/grab_points/grab_point_hand_left.tscn
+++ b/addons/godot-xr-tools/objects/grab_points/grab_point_hand_left.tscn
@@ -5,3 +5,4 @@
 [node name="GrabPointHandLeft" type="Marker3D"]
 visible = false
 script = ExtResource("1")
+hand_offset_mode = null

--- a/addons/godot-xr-tools/player/poke/poke.tscn
+++ b/addons/godot-xr-tools/player/poke/poke.tscn
@@ -16,7 +16,7 @@ height = 0.01
 radial_segments = 32
 rings = 16
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_hgik7"]
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_uvdwq"]
 transparency = 1
 shading_mode = 0
 albedo_color = Color(0.8, 0.8, 1, 0.5)
@@ -36,7 +36,7 @@ shape = SubResource("1")
 
 [node name="MeshInstance" type="MeshInstance3D" parent="PokeBody"]
 mesh = SubResource("2")
-surface_material_override/0 = SubResource("StandardMaterial3D_hgik7")
+surface_material_override/0 = SubResource("StandardMaterial3D_uvdwq")
 
 [node name="Rumbler" type="Node" parent="."]
 script = ExtResource("3_41fwo")

--- a/addons/godot-xr-tools/player/poke/poke_body.gd
+++ b/addons/godot-xr-tools/player/poke/poke_body.gd
@@ -25,10 +25,21 @@ func is_xr_class(name : String) -> bool:
 	return name == "XRToolsPokeBody" or super(name)
 
 
+func _validate_property(property):
+	if property.name == "top_level":
+		property.usage = PROPERTY_USAGE_NONE
+
+
 func _ready():
 	# Do not initialise if in the editor
 	if Engine.is_editor_hint():
+		# In editor, show it at its start location
+		top_level = false
+		transform = Transform3D()
 		return
+
+	# In runtime, we control the position
+	top_level = true
 
 	# Connect to player body signals (if applicable)
 	var player_body = XRToolsPlayerBody.find_instance(self)

--- a/addons/godot-xr-tools/xr_tools.gd
+++ b/addons/godot-xr-tools/xr_tools.gd
@@ -6,6 +6,26 @@ extends Node
 ## registered in plugin.gd.
 ## Some of these settings can be overridden by the user through user settings.
 
+## Offset modes
+enum HandOffsetMode {
+	HAND_OFFSET_AUTO, # Determine based on using default poses
+	HAND_OFFSET_AIM, # Our pose is an aim pose
+	HAND_OFFSET_GRIP, # Our pose is a grip pose
+	HAND_OFFSET_PALM # Our pose is a palm pose
+}
+
+# Map interaction profiles to grip rotations.
+# TODO We need to complete this with more controllers,
+static var grip_rotations: Dictionary[String, float] = {
+	"/interaction_profiles/oculus/touch_controller": deg_to_rad(-60.0),
+	"/interaction_profiles/facebook/touch_controller_pro": deg_to_rad(-60.0),
+	"/interaction_profiles/meta/touch_controller_plus": deg_to_rad(-60.0),
+	"/interaction_profiles/bytedance/pico4_controller": deg_to_rad(-40.0),
+	"/interaction_profiles/bytedance/pico4s_controller": deg_to_rad(-40.0),
+	"/interaction_profiles/bytedance/pico_ultra_controller_bd": deg_to_rad(-40.0)
+}
+
+## Get our configured grip threshold.
 static func get_grip_threshold() -> float:
 	# can return null which is not a float, so don't type this!
 	var threshold = 0.7
@@ -19,6 +39,8 @@ static func get_grip_threshold() -> float:
 
 	return threshold
 
+
+## Set our configured grip threshold.
 static func set_grip_threshold(p_threshold : float) -> void:
 	if !(p_threshold >= 0.2 and p_threshold <= 0.8):
 		print("Threshold out of bounds")
@@ -26,6 +48,8 @@ static func set_grip_threshold(p_threshold : float) -> void:
 
 	ProjectSettings.set_setting("godot_xr_tools/input/grip_threshold", p_threshold)
 
+
+## Get our y-axis dead zone.
 static func get_y_axis_dead_zone() -> float:
 	# can return null which is not a float, so don't type this!
 	var deadzone = 0.1
@@ -39,6 +63,8 @@ static func get_y_axis_dead_zone() -> float:
 
 	return deadzone
 
+
+## Set our y-axis dead zone.
 static func set_y_axis_dead_zone(p_deadzone : float) -> void:
 	if !(p_deadzone >= 0.0 and p_deadzone <= 0.5):
 		print("Deadzone out of bounds")
@@ -46,6 +72,8 @@ static func set_y_axis_dead_zone(p_deadzone : float) -> void:
 
 	ProjectSettings.set_setting("godot_xr_tools/input/y_axis_dead_zone", p_deadzone)
 
+
+## Get our x-axis dead zone.
 static func get_x_axis_dead_zone() -> float:
 	# can return null which is not a float, so don't type this!
 	var deadzone = 0.2
@@ -59,6 +87,8 @@ static func get_x_axis_dead_zone() -> float:
 
 	return deadzone
 
+
+## Set our x-axis dead zone.
 static func set_x_axis_dead_zone(p_deadzone : float) -> void:
 	if !(p_deadzone >= 0.0 and p_deadzone <= 0.5):
 		print("Deadzone out of bounds")
@@ -67,6 +97,7 @@ static func set_x_axis_dead_zone(p_deadzone : float) -> void:
 	ProjectSettings.set_setting("godot_xr_tools/input/x_axis_dead_zone", p_deadzone)
 
 
+## Get our snap turning dead zone.
 static func get_snap_turning_deadzone() -> float:
 	# can return null which is not a float, so don't type this!
 	var deadzone = 0.25
@@ -80,6 +111,8 @@ static func get_snap_turning_deadzone() -> float:
 
 	return deadzone
 
+
+## Set our snap turning dead zone.
 static func set_snap_turning_deadzone(p_deadzone : float) -> void:
 	if !(p_deadzone >= 0.0 and p_deadzone <= 0.5):
 		print("Deadzone out of bounds")
@@ -88,6 +121,7 @@ static func set_snap_turning_deadzone(p_deadzone : float) -> void:
 	ProjectSettings.set_setting("godot_xr_tools/input/snap_turning_deadzone", p_deadzone)
 
 
+## Get our default value for enabling snap turning.
 static func get_default_snap_turning() -> bool:
 	var default = true
 
@@ -97,10 +131,13 @@ static func get_default_snap_turning() -> bool:
 	# default may not be bool, so JIC
 	return default == true
 
+
+## Set our default value for enabling snap turning.
 static func set_default_snap_turning(p_default : bool) -> void:
 	ProjectSettings.set_setting("godot_xr_tools/input/default_snap_turning", p_default)
 
 
+## Get our player standard height.
 static func get_player_standard_height() -> float:
 	var standard_height = 1.85
 
@@ -113,12 +150,15 @@ static func get_player_standard_height() -> float:
 
 	return standard_height
 
+
+## Set our player standard height.
 static func set_player_standard_height(p_height : float) -> void:
 	if !(p_height >= 1.0 and p_height <= 2.5):
 		print("Standard height out of bounds")
 		return
 
 	ProjectSettings.set_setting("godot_xr_tools/player/standard_height", p_height)
+
 
 ## Find all children of the specified node matching the given criteria
 ##
@@ -148,6 +188,7 @@ static func find_xr_children(
 		_find_xr_children(found, node, pattern, type, recursive, owned)
 	return found
 
+
 ## Find a child of the specified node matching the given criteria
 ##
 ## This function finds the first child of the specified node matching the given
@@ -176,6 +217,7 @@ static func find_xr_child(
 	# Invalid node
 	return null
 
+
 ## Find an ancestor of the specified node matching the given criteria
 ##
 ## This function finds the first ancestor of the specified node matching the
@@ -203,6 +245,7 @@ static func find_xr_ancestor(
 	# Return found node (or null)
 	return node
 
+
 # Recursive helper function for find_children.
 static func _find_xr_children(
 		found : Array,
@@ -225,6 +268,7 @@ static func _find_xr_children(
 		# If recursive is enabled then descend into children
 		if recursive:
 			_find_xr_children(found, child, pattern, type, recursive, owned)
+
 
 # Recursive helper functiomn for find_child
 static func _find_xr_child(
@@ -253,6 +297,7 @@ static func _find_xr_child(
 	# Not found
 	return null
 
+
 # Test if a given node is of the specified class
 static func is_xr_class(node : Node, type : String) -> bool:
 	if node.has_method("is_xr_class"):
@@ -260,3 +305,129 @@ static func is_xr_class(node : Node, type : String) -> bool:
 			return true
 
 	return node.is_class(type)
+
+
+## Gets our grip rotation for various controller profiles.
+## Note that this is a guestimate and that in theory rotations
+## can vary between runtimes.
+static func get_grip_rotation(profile : String) -> float:
+	# TODO add in a way for users to override this through a setting.
+	if grip_rotations.has(profile):
+		return grip_rotations[profile]
+
+	# We return 45 degrees as a default
+	return deg_to_rad(-45.0)
+
+
+## Helper function to get a transform that offset the controller pose
+## so we center on the palm
+static func get_palm_offset(mode : HandOffsetMode, xr_controller : XRController3D) -> Transform3D:
+	var transform: Transform3D = Transform3D()
+	var is_left_hand: bool = true
+	var profile : String = ""
+
+	if xr_controller:
+		if xr_controller.tracker != "left_hand":
+			is_left_hand = false
+
+		var xr_tracker : XRControllerTracker = XRServer.get_tracker(xr_controller.tracker)
+		if xr_tracker:
+			profile = xr_tracker.profile
+
+		if mode != XRTools.HandOffsetMode.HAND_OFFSET_AUTO:
+			pass
+		elif xr_controller.pose == "aim":
+			mode = XRTools.HandOffsetMode.HAND_OFFSET_AIM
+		elif xr_controller.pose == "grip":
+			mode = XRTools.HandOffsetMode.HAND_OFFSET_GRIP
+		else:
+			# Assume we're using a palm pose
+			mode = XRTools.HandOffsetMode.HAND_OFFSET_PALM
+
+	match mode:
+		XRTools.HandOffsetMode.HAND_OFFSET_AUTO:
+			# No controller? keep identity transform
+			pass
+		XRTools.HandOffsetMode.HAND_OFFSET_AIM:
+			# These are our original aim offsets.
+			# They are fairly unreliable now for many headsets.
+			if is_left_hand:
+				transform.origin = Vector3(-0.02, -0.05, 0.10)
+			else:
+				transform.origin = Vector3(0.02, -0.05, 0.10)
+		XRTools.HandOffsetMode.HAND_OFFSET_GRIP:
+			# Grip, is rotated 45 degrees to be aligned with controller grip
+			# So we reverse the rotation
+			transform.basis = Basis(Vector3(1.0, 0.0, 0.0), get_grip_rotation(profile))
+
+			# Todo, we should offset.origin.x depending on the hand,
+			# as our grip pose is centered on the controller.
+			# But we need some sort of average, or possibly start maintaining
+			# a matrix of adjustments per interaction profile, which would suck.
+		XRTools.HandOffsetMode.HAND_OFFSET_PALM:
+			# Palm, identity transform does fine.
+			# Our palm pose should be in the correct location.
+			pass
+		_:
+			# Unsupported
+			pass
+
+	return transform
+
+
+## Helper function to get a transform that offset the controller pose
+## so we're at the aim position.
+## Note that if the aim pose is used, we use that location as is,
+## else we try and reproduce the original aim pose location,
+## which may be different.
+static func get_aim_offset(mode : HandOffsetMode, xr_controller : XRController3D) -> Transform3D:
+	var transform: Transform3D = Transform3D()
+	var is_left_hand: bool = true
+	var profile : String = ""
+
+	if xr_controller:
+		if xr_controller.tracker != "left_hand":
+			is_left_hand = false
+
+		var xr_tracker : XRControllerTracker = XRServer.get_tracker(xr_controller.tracker)
+		if xr_tracker:
+			profile = xr_tracker.profile
+
+		if mode != XRTools.HandOffsetMode.HAND_OFFSET_AUTO:
+			pass
+		elif xr_controller.pose == "aim":
+			mode = XRTools.HandOffsetMode.HAND_OFFSET_AIM
+		elif xr_controller.pose == "grip":
+			mode = XRTools.HandOffsetMode.HAND_OFFSET_GRIP
+		else:
+			# Assume we're using a palm pose
+			mode = XRTools.HandOffsetMode.HAND_OFFSET_PALM
+
+	match mode:
+		XRTools.HandOffsetMode.HAND_OFFSET_AUTO:
+			# No controller? keep identity transform
+			pass
+		XRTools.HandOffsetMode.HAND_OFFSET_AIM:
+			# Aim, identity transform is what we want.
+			pass
+		XRTools.HandOffsetMode.HAND_OFFSET_GRIP:
+			# Grip, is rotated 45 degrees to be aligned with controller grip
+			# So we reverse the rotation
+			transform.basis = Basis(Vector3(1.0, 0.0, 0.0), get_grip_rotation(profile))
+
+			# and offset
+			if is_left_hand:
+				transform.origin = transform.basis * Vector3(0.02, 0.05, -0.10)
+			else:
+				transform.origin = transform.basis * Vector3(-0.02, 0.05, -0.10)
+		XRTools.HandOffsetMode.HAND_OFFSET_PALM:
+			# Just offset
+			if is_left_hand:
+				transform.origin = Vector3(0.02, 0.05, -0.10)
+			else:
+				transform.origin = Vector3(-0.02, 0.05, -0.10)
+		_:
+			# Unsupported
+			pass
+
+	return transform

--- a/assets/3dmodelscc0/models/scenes/sniper_rifle.tscn
+++ b/assets/3dmodelscc0/models/scenes/sniper_rifle.tscn
@@ -152,6 +152,7 @@ surface_material_override/0 = ExtResource("8_7v2rw")
 surface_material_override/0 = ExtResource("8_7v2rw")
 
 [node name="FirearmSlide" type="Node3D" parent="sniper_rifle" index="1"]
+visible = false
 script = ExtResource("7_gwebu")
 slider_end = 0.072
 
@@ -163,13 +164,12 @@ collision_mask = 0
 [node name="HandleCollision" type="CollisionShape3D" parent="sniper_rifle/FirearmSlide/SliderBody" index="0"]
 shape = SubResource("SphereShape3D_exh4i")
 
-[node name="Bolt" type="MeshInstance3D" parent="sniper_rifle/FirearmSlide/SliderBody" index="1" node_paths=PackedStringArray("_owner", "_handle", "_slide")]
+[node name="Bolt" type="MeshInstance3D" parent="sniper_rifle/FirearmSlide/SliderBody" index="1" node_paths=PackedStringArray("_handle", "_slide")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00116384, 0.0329033, 0.153958)
 mesh = SubResource("ArrayMesh_rl240")
 skeleton = NodePath("")
 surface_material_override/0 = ExtResource("8_7v2rw")
 script = ExtResource("8_g4gvf")
-_owner = NodePath("../../../..")
 _handle = NodePath("../../HandleOrigin/InteractableHandle")
 _slide = NodePath("../..")
 value = Vector3(0, 0, 75)

--- a/assets/digitaln8m4r3/scripts/firearm_bolt.gd
+++ b/assets/digitaln8m4r3/scripts/firearm_bolt.gd
@@ -1,3 +1,4 @@
+@tool
 class_name XRFirearmBolt
 extends MeshInstance3D
 

--- a/assets/maps/holodeck/materials/holodeck_map_shader_with_alpha.tres
+++ b/assets/maps/holodeck/materials/holodeck_map_shader_with_alpha.tres
@@ -109,12 +109,12 @@ render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_s
 
 
 // Varyings
-varying vec3 world_pos;
+varying vec3 var_world_pos;
 
 uniform vec2 grid_scale = vec2(1.000000, 1.000000);
 uniform vec4 grid_color : source_color = vec4(1.000000, 0.891186, 0.000000, 1.000000);
 uniform sampler2D grid_texture : source_color, filter_linear_mipmap, repeat_enable;
-uniform float depth_fade = 2;
+uniform float depth_fade = 2.0;
 
 
 
@@ -154,7 +154,7 @@ void vertex() {
 
 
 // VaryingSetter:15
-	world_pos = n_out8p0;
+	var_world_pos = n_out8p0;
 
 
 }
@@ -174,7 +174,7 @@ void fragment() {
 
 
 // VaryingGetter:6
-	vec3 n_out6p0 = world_pos;
+	vec3 n_out6p0 = var_world_pos;
 
 
 // VectorDecompose:11

--- a/assets/meshes/control_pad/control_pad_location_left.tscn
+++ b/assets/meshes/control_pad/control_pad_location_left.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=2 format=3 uid="uid://bwr0eqi231lf0"]
+[gd_scene load_steps=3 format=3 uid="uid://bwr0eqi231lf0"]
 
 [ext_resource type="Script" uid="uid://ov7v57ikcyl5" path="res://assets/meshes/control_pad/control_pad_location.gd" id="1_4uvgi"]
+[ext_resource type="Script" uid="uid://drbnpanwky1vo" path="res://addons/godot-xr-tools/hands/hand_palm_offset.gd" id="1_au48i"]
 
 [node name="ControlPadLocationLeft" type="Node3D"]
+script = ExtResource("1_au48i")
 
 [node name="Position" type="Node3D" parent="."]
-transform = Transform3D(1.91069e-15, -1, -4.37114e-08, -0.0871558, -4.35451e-08, 0.996195, -0.996195, 3.8097e-09, -0.0871558, -0.03, 0, 0.3)
+transform = Transform3D(1.91069e-15, -1, -4.37114e-08, -0.0871558, -4.35451e-08, 0.996195, -0.996195, 3.8097e-09, -0.0871558, 0, 0.05, 0.2)
 script = ExtResource("1_4uvgi")

--- a/assets/meshes/control_pad/control_pad_location_right.tscn
+++ b/assets/meshes/control_pad/control_pad_location_right.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=2 format=3 uid="uid://deyk5frilshws"]
+[gd_scene load_steps=3 format=3 uid="uid://deyk5frilshws"]
 
 [ext_resource type="Script" uid="uid://ov7v57ikcyl5" path="res://assets/meshes/control_pad/control_pad_location.gd" id="1_nolsk"]
+[ext_resource type="Script" uid="uid://drbnpanwky1vo" path="res://addons/godot-xr-tools/hands/hand_palm_offset.gd" id="1_yrdf8"]
 
 [node name="ControlPadLocationRight" type="Node3D"]
+script = ExtResource("1_yrdf8")
 
 [node name="Position" type="Node3D" parent="."]
-transform = Transform3D(-5.73206e-15, 1, -1.31134e-07, 0.0871558, 1.30635e-07, 0.996195, 0.996195, -1.14291e-08, -0.0871558, 0.03, 0, 0.3)
+transform = Transform3D(-5.73206e-15, 1, -1.31134e-07, 0.0871558, 1.30635e-07, 0.996195, 0.996195, -1.14291e-08, -0.0871558, 0, 0.05, 0.2)
 script = ExtResource("1_nolsk")

--- a/openxr_action_map.tres
+++ b/openxr_action_map.tres
@@ -1,4 +1,4 @@
-[gd_resource type="OpenXRActionMap" load_steps=370 format=3 uid="uid://cv1tl7assnmqv"]
+[gd_resource type="OpenXRActionMap" load_steps=401 format=3 uid="uid://cv1tl7assnmqv"]
 
 [sub_resource type="OpenXRAction" id="OpenXRAction_yifcd"]
 resource_name = "trigger"
@@ -1521,6 +1521,130 @@ binding_path = "/user/vive_tracker_htcx/role/keyboard/output/haptic"
 interaction_profile_path = "/interaction_profiles/htc/vive_tracker_htcx"
 bindings = [SubResource("OpenXRIPBinding_xh6fl"), SubResource("OpenXRIPBinding_ixewl"), SubResource("OpenXRIPBinding_qwqvw"), SubResource("OpenXRIPBinding_oqlrv"), SubResource("OpenXRIPBinding_jw3vw"), SubResource("OpenXRIPBinding_3bjy3"), SubResource("OpenXRIPBinding_8upnq"), SubResource("OpenXRIPBinding_0w2ls"), SubResource("OpenXRIPBinding_u8hab"), SubResource("OpenXRIPBinding_eikk2"), SubResource("OpenXRIPBinding_5lybe"), SubResource("OpenXRIPBinding_l4y5i"), SubResource("OpenXRIPBinding_f7m66"), SubResource("OpenXRIPBinding_d13a6"), SubResource("OpenXRIPBinding_wxcrn"), SubResource("OpenXRIPBinding_6k8ea"), SubResource("OpenXRIPBinding_1qemc"), SubResource("OpenXRIPBinding_8u6xu"), SubResource("OpenXRIPBinding_7camc"), SubResource("OpenXRIPBinding_0fset"), SubResource("OpenXRIPBinding_ei7tg"), SubResource("OpenXRIPBinding_c2jdk"), SubResource("OpenXRIPBinding_g5ap7"), SubResource("OpenXRIPBinding_bw6j3")]
 
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_gsob2"]
+action = SubResource("OpenXRAction_6cxc5")
+binding_path = "/user/hand/left/input/aim/pose"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_145o5"]
+action = SubResource("OpenXRAction_1qblt")
+binding_path = "/user/hand/left/input/grip/pose"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_p8l30"]
+action = SubResource("OpenXRAction_c3bvs")
+binding_path = "/user/hand/left/input/palm_ext/pose"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_qwnvq"]
+action = SubResource("OpenXRAction_6cxc5")
+binding_path = "/user/hand/right/input/aim/pose"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_1o618"]
+action = SubResource("OpenXRAction_1qblt")
+binding_path = "/user/hand/right/input/grip/pose"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_k8gkf"]
+action = SubResource("OpenXRAction_c3bvs")
+binding_path = "/user/hand/right/input/palm_ext/pose"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_7atrr"]
+action = SubResource("OpenXRAction_yifcd")
+binding_path = "/user/hand/left/input/trigger/value"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_nc7nm"]
+action = SubResource("OpenXRAction_u273q")
+binding_path = "/user/hand/left/input/squeeze/value"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_u48na"]
+action = SubResource("OpenXRAction_mgaer")
+binding_path = "/user/hand/left/input/thumbstick"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_qo7i1"]
+action = SubResource("OpenXRAction_x2ltk")
+binding_path = "/user/hand/left/input/thumbstick/click"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_spwgl"]
+action = SubResource("OpenXRAction_52a4b")
+binding_path = "/user/hand/left/input/thumbstick/touch"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_6v1vi"]
+action = SubResource("OpenXRAction_gdvbe")
+binding_path = "/user/hand/left/input/trigger/touch"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_fwqq1"]
+action = SubResource("OpenXRAction_tbcxk")
+binding_path = "/user/hand/left/output/haptic"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_felwo"]
+action = SubResource("OpenXRAction_rju0c")
+binding_path = "/user/hand/left/input/x/click"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_okaja"]
+action = SubResource("OpenXRAction_k16im")
+binding_path = "/user/hand/left/input/x/touch"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_nim4l"]
+action = SubResource("OpenXRAction_puvt0")
+binding_path = "/user/hand/left/input/y/click"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_7rbtf"]
+action = SubResource("OpenXRAction_cjtwq")
+binding_path = "/user/hand/left/input/y/touch"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_vivrk"]
+action = SubResource("OpenXRAction_yifcd")
+binding_path = "/user/hand/right/input/trigger/value"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_1xhyi"]
+action = SubResource("OpenXRAction_d0pni")
+binding_path = "/user/hand/left/input/trigger/value"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_kfc2j"]
+action = SubResource("OpenXRAction_d0pni")
+binding_path = "/user/hand/right/input/trigger/value"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_osn8p"]
+action = SubResource("OpenXRAction_gdvbe")
+binding_path = "/user/hand/right/input/trigger/touch"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_o7rx2"]
+action = SubResource("OpenXRAction_u273q")
+binding_path = "/user/hand/right/input/squeeze/value"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_egnh2"]
+action = SubResource("OpenXRAction_mgaer")
+binding_path = "/user/hand/right/input/thumbstick"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_qdg3g"]
+action = SubResource("OpenXRAction_x2ltk")
+binding_path = "/user/hand/right/input/thumbstick/click"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_1m4jk"]
+action = SubResource("OpenXRAction_52a4b")
+binding_path = "/user/hand/right/input/thumbstick/touch"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_mq2is"]
+action = SubResource("OpenXRAction_tbcxk")
+binding_path = "/user/hand/right/output/haptic"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_j4oh5"]
+action = SubResource("OpenXRAction_rju0c")
+binding_path = "/user/hand/right/input/a/click"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_ldfim"]
+action = SubResource("OpenXRAction_k16im")
+binding_path = "/user/hand/right/input/a/touch"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_m7usb"]
+action = SubResource("OpenXRAction_puvt0")
+binding_path = "/user/hand/right/input/b/click"
+
+[sub_resource type="OpenXRIPBinding" id="OpenXRIPBinding_kby14"]
+action = SubResource("OpenXRAction_cjtwq")
+binding_path = "/user/hand/right/input/b/touch"
+
+[sub_resource type="OpenXRInteractionProfile" id="OpenXRInteractionProfile_1qtbb"]
+interaction_profile_path = "/interaction_profiles/bytedance/pico4_controller"
+bindings = [SubResource("OpenXRIPBinding_gsob2"), SubResource("OpenXRIPBinding_145o5"), SubResource("OpenXRIPBinding_p8l30"), SubResource("OpenXRIPBinding_qwnvq"), SubResource("OpenXRIPBinding_1o618"), SubResource("OpenXRIPBinding_k8gkf"), SubResource("OpenXRIPBinding_7atrr"), SubResource("OpenXRIPBinding_nc7nm"), SubResource("OpenXRIPBinding_u48na"), SubResource("OpenXRIPBinding_qo7i1"), SubResource("OpenXRIPBinding_spwgl"), SubResource("OpenXRIPBinding_6v1vi"), SubResource("OpenXRIPBinding_fwqq1"), SubResource("OpenXRIPBinding_felwo"), SubResource("OpenXRIPBinding_okaja"), SubResource("OpenXRIPBinding_nim4l"), SubResource("OpenXRIPBinding_7rbtf"), SubResource("OpenXRIPBinding_vivrk"), SubResource("OpenXRIPBinding_1xhyi"), SubResource("OpenXRIPBinding_kfc2j"), SubResource("OpenXRIPBinding_osn8p"), SubResource("OpenXRIPBinding_o7rx2"), SubResource("OpenXRIPBinding_egnh2"), SubResource("OpenXRIPBinding_qdg3g"), SubResource("OpenXRIPBinding_1m4jk"), SubResource("OpenXRIPBinding_mq2is"), SubResource("OpenXRIPBinding_j4oh5"), SubResource("OpenXRIPBinding_ldfim"), SubResource("OpenXRIPBinding_m7usb"), SubResource("OpenXRIPBinding_kby14")]
+
 [resource]
 action_sets = [SubResource("OpenXRActionSet_hc02c")]
-interaction_profiles = [SubResource("OpenXRInteractionProfile_q4jv5"), SubResource("OpenXRInteractionProfile_gh0s5"), SubResource("OpenXRInteractionProfile_hk3uy"), SubResource("OpenXRInteractionProfile_ci0m3"), SubResource("OpenXRInteractionProfile_8ffkv"), SubResource("OpenXRInteractionProfile_s65fn"), SubResource("OpenXRInteractionProfile_7w34y"), SubResource("OpenXRInteractionProfile_a7xw5"), SubResource("OpenXRInteractionProfile_rsga2"), SubResource("OpenXRInteractionProfile_t3axk"), SubResource("OpenXRInteractionProfile_2ydwc")]
+interaction_profiles = [SubResource("OpenXRInteractionProfile_q4jv5"), SubResource("OpenXRInteractionProfile_gh0s5"), SubResource("OpenXRInteractionProfile_hk3uy"), SubResource("OpenXRInteractionProfile_ci0m3"), SubResource("OpenXRInteractionProfile_8ffkv"), SubResource("OpenXRInteractionProfile_s65fn"), SubResource("OpenXRInteractionProfile_7w34y"), SubResource("OpenXRInteractionProfile_a7xw5"), SubResource("OpenXRInteractionProfile_rsga2"), SubResource("OpenXRInteractionProfile_t3axk"), SubResource("OpenXRInteractionProfile_2ydwc"), SubResource("OpenXRInteractionProfile_1qtbb")]

--- a/scenes/audio_demo/audio_demo.tscn
+++ b/scenes/audio_demo/audio_demo.tscn
@@ -30,65 +30,65 @@
 [ext_resource type="PackedScene" uid="uid://diyu4g17s0n8g" path="res://scenes/audio_demo/objects/arcade_hoops.tscn" id="21_v27ri"]
 [ext_resource type="PackedScene" uid="uid://c8v28upinm8k8" path="res://scenes/audio_demo/objects/instructions.tscn" id="22_8pmnk"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ligbi"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_itsrc"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_8t4j7"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_qdo1x"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_i117w"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_fs0ci"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_i7m8d"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_j7lgi"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_wy1bl"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_5rv4h"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_etuq8"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_yfukw"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_ligbi")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_itsrc")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_8t4j7")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_qdo1x")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_i117w")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_fs0ci")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_i7m8d")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_j7lgi")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_wy1bl")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_5rv4h")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_7f4qn"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_2lrqb"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_3v734"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_x4swr"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_7okmi"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_17af5"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_4jnwv"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_rxmv0"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_n3exj"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_0ce6k"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_wavfh"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_qaj4i"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_7f4qn")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_2lrqb")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_3v734")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_x4swr")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_7okmi")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_17af5")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_4jnwv")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_rxmv0")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_n3exj")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_0ce6k")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -103,10 +103,18 @@ walk_pitch_maximum = 1.2
 [node name="AudioDemo" instance=ExtResource("1_jceij")]
 script = ExtResource("2_tafmy")
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftPhysicsHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("3_xxmgq")]
 
+[node name="Hand_Nails_low_L" parent="XROrigin3D/LeftHand/LeftPhysicsHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftPhysicsHand/Hand_Nails_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -127,7 +135,7 @@ bones/22/rotation = Quaternion(0.0585786, 0.0216483, -0.269905, 0.96086)
 bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
 
 [node name="BoneRoot" parent="XROrigin3D/LeftHand/LeftPhysicsHand/Hand_Nails_low_L/Armature/Skeleton3D" index="1"]
-transform = Transform3D(1, -1.83077e-05, 1.52659e-08, 1.52668e-08, 0.00166774, 0.999999, -1.83077e-05, -0.999999, 0.00166774, 3.86425e-08, -1.86975e-05, 0.0271756)
+transform = Transform3D(1, -1.83077e-05, 1.5264e-08, 1.52677e-08, 0.00166774, 0.999999, -1.83077e-05, -0.999999, 0.00166774, 3.86425e-08, -1.86975e-05, 0.0271756)
 
 [node name="BoneThumbMetacarpal" parent="XROrigin3D/LeftHand/LeftPhysicsHand/Hand_Nails_low_L/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, 0.0514604, -0.0176509, -0.017651, 0.613335, 0.789626, 0.0514604, -0.788145, 0.613335, 0.00999954, 0.0200266, 3.59323e-05)
@@ -169,7 +177,7 @@ transform = Transform3D(0.998609, 0.047074, 0.0237409, -0.0169882, -0.138981, 0.
 transform = Transform3D(0.982964, 0.181854, 0.0266582, 0.0109494, -0.202722, 0.979175, 0.183471, -0.962202, -0.20126, -0.00651963, -0.0233502, -0.0731075)
 
 [node name="BoneRingMiddle" parent="XROrigin3D/LeftHand/LeftPhysicsHand/Hand_Nails_low_L/Armature/Skeleton3D" index="15"]
-transform = Transform3D(0.772579, 0.634603, 0.0200164, 0.0794845, -0.127948, 0.98859, 0.629924, -0.762173, -0.149291, 0.000778393, -0.0314857, -0.111722)
+transform = Transform3D(0.772579, 0.634603, 0.0200164, 0.0794845, -0.127948, 0.98859, 0.629924, -0.762173, -0.149291, 0.000778394, -0.0314857, -0.111722)
 
 [node name="BoneRingDistal" parent="XROrigin3D/LeftHand/LeftPhysicsHand/Hand_Nails_low_L/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381387, 0.924068, 0.025339, 0.114105, -0.0742599, 0.990689, 0.917346, -0.374945, -0.133762, 0.0184188, -0.0350424, -0.132908)
@@ -197,23 +205,35 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftPhysicsHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_etuq8")
+root_node = NodePath("../Hand_Nails_low_L")
+tree_root = SubResource("AnimationNodeBlendTree_yfukw")
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("4_1uxxi")]
 strafe = true
 
 [node name="FunctionPickup" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("5_02uus")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 grab_distance = 0.1
 ranged_angle = 10.0
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("6_131o8")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="4" instance=ExtResource("7_xr2gq")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightPhysicsHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("6_vetbi")]
 
+[node name="Hand_Nails_low_R" parent="XROrigin3D/RightHand/RightPhysicsHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -234,7 +254,7 @@ bones/22/rotation = Quaternion(0.0585786, -0.0216483, 0.269905, 0.96086)
 bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 
 [node name="BoneRoot" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature/Skeleton3D" index="1"]
-transform = Transform3D(1, 1.83077e-05, -1.52659e-08, -1.52668e-08, 0.00166774, 0.999999, 1.83077e-05, -0.999999, 0.00166774, -3.86425e-08, -1.86975e-05, 0.0271756)
+transform = Transform3D(1, 1.83077e-05, -1.5264e-08, -1.52677e-08, 0.00166774, 0.999999, 1.83077e-05, -0.999999, 0.00166774, -3.86425e-08, -1.86975e-05, 0.0271756)
 
 [node name="BoneThumbMetacarpal" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, -0.0514604, 0.0176509, 0.017651, 0.613335, 0.789626, -0.0514604, -0.788145, 0.613335, -0.00999954, 0.0200266, 3.59323e-05)
@@ -276,10 +296,10 @@ transform = Transform3D(0.998609, -0.047074, -0.0237409, 0.0169882, -0.138981, 0
 transform = Transform3D(0.982964, -0.181854, -0.0266582, -0.0109494, -0.202722, 0.979175, -0.183471, -0.962202, -0.20126, 0.00651963, -0.0233502, -0.0731075)
 
 [node name="BoneRingMiddle" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature/Skeleton3D" index="15"]
-transform = Transform3D(0.772579, -0.634603, -0.0200164, -0.0794844, -0.127948, 0.98859, -0.629924, -0.762173, -0.149291, -0.000778395, -0.0314857, -0.111722)
+transform = Transform3D(0.772579, -0.634603, -0.0200164, -0.0794844, -0.127948, 0.98859, -0.629924, -0.762173, -0.149291, -0.000778396, -0.0314857, -0.111722)
 
 [node name="BoneRingDistal" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature/Skeleton3D" index="16"]
-transform = Transform3D(0.381388, -0.924068, -0.025339, -0.114105, -0.0742599, 0.990689, -0.917346, -0.374945, -0.133762, -0.0184188, -0.0350424, -0.132908)
+transform = Transform3D(0.381387, -0.924068, -0.025339, -0.114105, -0.0742599, 0.990689, -0.917346, -0.374945, -0.133762, -0.0184188, -0.0350424, -0.132908)
 
 [node name="BonePinkyMetacarpal" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, -0.0165318, -0.0422887, 0.0385953, -0.181426, 0.982647, -0.0239172, -0.983265, -0.180601, 4.58211e-07, -0.0299734, 3.59304e-05)
@@ -304,23 +324,28 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightPhysicsHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_wavfh")
+root_node = NodePath("../Hand_Nails_low_R")
+tree_root = SubResource("AnimationNodeBlendTree_qaj4i")
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("4_1uxxi")]
 
 [node name="MovementTurn" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("7_h0ohr")]
 
 [node name="FunctionPickup" parent="XROrigin3D/RightHand" index="3" instance=ExtResource("5_02uus")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 grab_distance = 0.1
 ranged_angle = 10.0
 
 [node name="FunctionPointer" parent="XROrigin3D/RightHand" index="4" instance=ExtResource("8_bx0ud")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.02, -0.0353553, -0.106066)
 show_laser = 2
 laser_length = 1
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("6_131o8")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="6" instance=ExtResource("11_7wxsm")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("9_8cb2y")]
 
@@ -333,7 +358,6 @@ default_surface_audio_type = SubResource("Resource_ppd3h")
 
 [node name="Teleport" parent="." index="2" instance=ExtResource("13_nq2ma")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4)
-scene_base = NodePath("..")
 title = ExtResource("14_17t48")
 
 [node name="Instructions" parent="." index="3" instance=ExtResource("22_8pmnk")]

--- a/scenes/basic_movement_demo/basic_movement_demo.tscn
+++ b/scenes/basic_movement_demo/basic_movement_demo.tscn
@@ -24,65 +24,65 @@
 [ext_resource type="PackedScene" uid="uid://bt08qiog5e1ct" path="res://scenes/basic_movement_demo/objects/fade_instructions.tscn" id="21_g78p4"]
 [ext_resource type="PackedScene" uid="uid://bintvchia5op" path="res://scenes/basic_movement_demo/objects/damage_area.tscn" id="23_cr5qc"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_37foi"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_uvnkc"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_sydnu"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_148ws"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_aoh1o"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ysvlc"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_1vgdw"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_kaxp4"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_e4xgg"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_v2esc"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_6l68f"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_0mnst"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_37foi")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_uvnkc")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_sydnu")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_148ws")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_aoh1o")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_ysvlc")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_1vgdw")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_kaxp4")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_e4xgg")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_v2esc")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_eydra"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_jqjo6"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_owrx7"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_rdocr"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_xaadv"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ixrru"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_46osi"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_iwb3b"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ud3j8"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_owxvd"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_y60kp"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_d828g"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_eydra")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_jqjo6")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_owrx7")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_rdocr")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_xaadv")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_ixrru")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_46osi")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_iwb3b")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_ud3j8")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_owxvd")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -103,10 +103,18 @@ script = ExtResource("2_5ptmo")
 
 [node name="FadeCollision" parent="XROrigin3D/XRCamera3D" index="0" instance=ExtResource("3_bvrj7")]
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("2_54yy3")]
 
+[node name="Hand_Nails_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -137,7 +145,8 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_6l68f")
+root_node = NodePath("../Hand_Nails_low_L")
+tree_root = SubResource("AnimationNodeBlendTree_0mnst")
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("5")]
 strafe = true
@@ -150,11 +159,20 @@ crouch_height = 1.3
 crouch_button_action = "by_button"
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="4" instance=ExtResource("8_0sv1b")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("6_0hbex")]
 
+[node name="Hand_Nails_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -185,7 +203,7 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_y60kp")
+tree_root = SubResource("AnimationNodeBlendTree_d828g")
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("5")]
 
@@ -200,6 +218,7 @@ crouch_button_action = "by_button"
 crouch_type = 1
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("11_k0f5x")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("6")]
 
@@ -222,9 +241,6 @@ collision_layer = 3
 [node name="MainMenuTeleport" parent="." index="2" instance=ExtResource("11")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 7)
 title = ExtResource("12")
-spawn_point_name = ""
-spawn_point_position = Vector3(0, 0, 0)
-spawn_point_transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="Instructions" parent="." index="3" instance=ExtResource("12_qasi6")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, -4)

--- a/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
+++ b/scenes/climbing_gliding_demo/climbing_gliding_demo.tscn
@@ -28,65 +28,65 @@
 [ext_resource type="PackedScene" uid="uid://bgts3vpmjn6bb" path="res://addons/godot-xr-tools/functions/movement_wind.tscn" id="22"]
 [ext_resource type="PackedScene" uid="uid://q3pa72xp41cq" path="res://scenes/climbing_gliding_demo/objects/ladder.tscn" id="27_mmo3a"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_lj651"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_g5foc"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_5hu3r"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_0qjai"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_k4gv5"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_5imwg"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_f11fi"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_b2xvg"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_2dm6d"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_23qfq"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_xv4cn"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_52h21"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_lj651")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_g5foc")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_5hu3r")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_0qjai")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_k4gv5")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_5imwg")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_f11fi")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_b2xvg")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_2dm6d")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_23qfq")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_kwr4e"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_5sya4"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_at15v"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_6ykh0"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_3qnl1"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_xjyqi"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_j56mo"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_fp6qg"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_cjhu6"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_datwe"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_6km0q"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_awevd"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_kwr4e")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_5sya4")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_at15v")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_6ykh0")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_3qnl1")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_xjyqi")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_j56mo")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_fp6qg")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_cjhu6")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_datwe")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -108,11 +108,19 @@ transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -89, 3
 [node name="XRCamera3D" parent="XROrigin3D" index="0"]
 far = 400.0
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("2_xkd6u")]
 hand_material_override = ExtResource("8_cr7b0")
 
+[node name="Hand_Nails_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -146,23 +154,34 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_xv4cn")
+root_node = NodePath("../Hand_Nails_low_L")
+tree_root = SubResource("AnimationNodeBlendTree_52h21")
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("5")]
 strafe = true
 
 [node name="FunctionPickup" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("9")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="MovementJump" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("15")]
 jump_button_action = "ax_button"
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="4" instance=ExtResource("10_3kap6")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("6_vqlyr")]
 hand_material_override = ExtResource("8_cr7b0")
 
+[node name="Hand_Nails_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -196,18 +215,20 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_6km0q")
+tree_root = SubResource("AnimationNodeBlendTree_awevd")
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("5")]
 
 [node name="MovementTurn" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("4")]
 
 [node name="FunctionPickup" parent="XROrigin3D/RightHand" index="3" instance=ExtResource("9")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="MovementJump" parent="XROrigin3D/RightHand" index="4" instance=ExtResource("15")]
 jump_button_action = "ax_button"
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("13_76s1p")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("6")]
 
@@ -376,16 +397,10 @@ transform = Transform3D(-0.880477, 0, -0.474088, 0, 1, 0, 0.474088, 0, -0.880477
 [node name="MainMenuTeleport1" parent="." index="4" instance=ExtResource("14")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -83, 36, -68)
 title = ExtResource("13")
-spawn_point_name = ""
-spawn_point_position = Vector3(0, 0, 0)
-spawn_point_transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="MainMenuTeleport2" parent="." index="5" instance=ExtResource("14")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 91, 6, 81)
 title = ExtResource("13")
-spawn_point_name = ""
-spawn_point_position = Vector3(0, 0, 0)
-spawn_point_transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="Instructions" parent="." index="6" instance=ExtResource("19_3dxda")]
 transform = Transform3D(-0.5, 0, -0.866025, 0, 1, 0, 0.866025, 0, -0.5, -80, 40, -60)

--- a/scenes/climbing_gliding_demo/objects/wind_area_shader.tres
+++ b/scenes/climbing_gliding_demo/objects/wind_area_shader.tres
@@ -47,7 +47,7 @@ input_name = "uv"
 
 [sub_resource type="VisualShader" id="VisualShader_buj8i"]
 code = "shader_type spatial;
-render_mode blend_add, cull_disabled, unshaded;
+render_mode blend_add, depth_draw_opaque, cull_disabled, diffuse_lambert, specular_schlick_ggx, unshaded;
 
 
 

--- a/scenes/footstep_movement_demo/footstep_movement_demo.tscn
+++ b/scenes/footstep_movement_demo/footstep_movement_demo.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=20 format=3 uid="uid://dt5jsm43uk88b"]
+[gd_scene load_steps=19 format=3 uid="uid://dt5jsm43uk88b"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="Script" uid="uid://clipxhr1jpdbq" path="res://scenes/demo_scene_base.gd" id="1_yauh3"]
 [ext_resource type="PackedScene" uid="uid://clt88d5d1dje4" path="res://addons/godot-xr-tools/functions/movement_crouch.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://mnoirgubr2js" path="res://scenes/footstep_movement_demo/objects/instructions.tscn" id="3_8248t"]
-[ext_resource type="Environment" uid="uid://bacqoq62qs27y" path="res://assets/maps/holodeck/holodeck_env.tres" id="3_virb4"]
 [ext_resource type="PackedScene" uid="uid://diyu06cw06syv" path="res://addons/godot-xr-tools/player/player_body.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://bl2nuu3qhlb5k" path="res://addons/godot-xr-tools/functions/movement_direct.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://b4kad2kuba1yn" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/left_hand_low.tscn" id="6"]
@@ -29,7 +28,11 @@ walk_pitch_maximum = 1.2
 
 [node name="FootstepMovementDemo" instance=ExtResource("1")]
 script = ExtResource("1_yauh3")
-environment = ExtResource("3_virb4")
+
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("6")]
 
@@ -42,6 +45,11 @@ jump_button_action = "ax_button"
 [node name="MovementCrouch" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("3")]
 crouch_height = 1.3
 crouch_button_action = "by_button"
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("8")]
 
@@ -64,7 +72,6 @@ default_surface_audio_type = SubResource("Resource_lclo7")
 
 [node name="MainMenuTeleport" parent="." index="1" instance=ExtResource("11")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 7)
-scene_base = NodePath("..")
 title = ExtResource("10")
 
 [node name="Instructions" parent="." index="2" instance=ExtResource("3_8248t")]

--- a/scenes/grappling_demo/grappling_demo.tscn
+++ b/scenes/grappling_demo/grappling_demo.tscn
@@ -23,65 +23,65 @@
 [ext_resource type="PackedScene" uid="uid://ct3p5sgwvkmva" path="res://assets/meshes/control_pad/control_pad.tscn" id="16_1fvg5"]
 [ext_resource type="PackedScene" uid="uid://lelocs2v705t" path="res://scenes/grappling_demo/objects/tower.tscn" id="18"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_iwdon"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_1kb2r"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_tre57"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_0fi3f"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ixo0l"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_qgpbs"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_aqnt4"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_j4ihq"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_8ru1r"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_g75eo"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_vbmv6"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_iyqin"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_iwdon")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_1kb2r")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_tre57")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_0fi3f")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_ixo0l")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_qgpbs")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_aqnt4")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_j4ihq")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_8ru1r")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_g75eo")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ea3j6"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_os25x"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_gg4cx"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_27jkk"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_lm5p4"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ux8qw"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_e3ij2"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_kj527"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_p7pwi"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_iuiv0"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_5pkqv"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_r85co"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_ea3j6")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_os25x")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_gg4cx")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_27jkk")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_lm5p4")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_ux8qw")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_e3ij2")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_kj527")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_p7pwi")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_iuiv0")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -91,10 +91,18 @@ script = ExtResource("2_lm0po")
 [node name="XROrigin3D" parent="." index="0"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 28)
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("2_7xgbg")]
 
+[node name="Hand_Nails_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -125,23 +133,33 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_vbmv6")
+root_node = NodePath("../Hand_Nails_low_L")
+tree_root = SubResource("AnimationNodeBlendTree_iyqin")
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("3")]
 strafe = true
 
 [node name="MovementJump" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("5")]
-jump_button_action = "ax_button"
 
 [node name="FunctionPickup" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("8")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 ranged_enable = false
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="4" instance=ExtResource("8_bqtqi")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("6_n2v2n")]
 
+[node name="Hand_Nails_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -172,21 +190,23 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_5pkqv")
+tree_root = SubResource("AnimationNodeBlendTree_r85co")
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("3")]
 
 [node name="MovementTurn" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("7")]
 
 [node name="MovementJump" parent="XROrigin3D/RightHand" index="3" instance=ExtResource("5")]
-jump_button_action = "ax_button"
 
 [node name="MovementGrapple" parent="XROrigin3D/RightHand" index="4" instance=ExtResource("2")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="FunctionPickup" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("8")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 ranged_enable = false
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="6" instance=ExtResource("12_mvj1t")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("11")]
 
@@ -200,7 +220,6 @@ ranged_enable = false
 
 [node name="ToMainMenu" parent="." index="2" instance=ExtResource("14")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 32)
-scene_base = NodePath("..")
 title = ExtResource("15")
 
 [node name="Instructions" parent="." index="3" instance=ExtResource("15_vd3ki")]

--- a/scenes/helpers/axis/axis.gd
+++ b/scenes/helpers/axis/axis.gd
@@ -1,0 +1,15 @@
+@tool
+extends Node3D
+
+@export_multiline var label : String = "XRNode3D":
+	set(value):
+		label = value
+		if is_inside_tree():
+			_update_label()
+
+func _update_label():
+	$Label3D.text = label
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	_update_label()

--- a/scenes/helpers/axis/axis.gd.uid
+++ b/scenes/helpers/axis/axis.gd.uid
@@ -1,0 +1,1 @@
+uid://d1p1vt17nrxaa

--- a/scenes/helpers/axis/axis.tscn
+++ b/scenes/helpers/axis/axis.tscn
@@ -1,0 +1,52 @@
+[gd_scene load_steps=3 format=3 uid="uid://ss6ydhkwbtrl"]
+
+[ext_resource type="Script" uid="uid://d1p1vt17nrxaa" path="res://scenes/helpers/axis/axis.gd" id="1_8umds"]
+[ext_resource type="PackedScene" uid="uid://cfnu7rw2u32xx" path="res://scenes/helpers/axis/vector.tscn" id="1_axhod"]
+
+[node name="Axis" type="Node3D"]
+script = ExtResource("1_8umds")
+
+[node name="Forward" parent="." instance=ExtResource("1_axhod")]
+color = Color(0, 0, 1, 1)
+
+[node name="Z" type="Label3D" parent="Forward"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.125)
+layers = 4
+pixel_size = 0.001
+billboard = 2
+modulate = Color(0, 0, 1, 1)
+text = "Z"
+
+[node name="Up" parent="." instance=ExtResource("1_axhod")]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0)
+color = Color(0, 1, 0, 1)
+
+[node name="Y" type="Label3D" parent="Up"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.125)
+layers = 4
+pixel_size = 0.001
+billboard = 2
+modulate = Color(0, 1, 0, 1)
+text = "Y
+"
+
+[node name="Left" parent="." instance=ExtResource("1_axhod")]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 0, 0, 0)
+color = Color(1, 0, 0, 1)
+
+[node name="X" type="Label3D" parent="Left"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.125)
+layers = 4
+pixel_size = 0.001
+billboard = 2
+modulate = Color(1, 0, 0, 1)
+text = "X	"
+
+[node name="Label3D" type="Label3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.01, 0.01, 0)
+layers = 4
+pixel_size = 0.001
+billboard = 2
+text = "XRNode3D"
+horizontal_alignment = 0
+vertical_alignment = 2

--- a/scenes/helpers/axis/vector.gd
+++ b/scenes/helpers/axis/vector.gd
@@ -1,0 +1,15 @@
+@tool
+extends Node3D
+
+@export var color : Color = Color(1.0, 1.0, 1.0, 1.0):
+	set(value):
+		color = value
+		if is_inside_tree():
+			_on_color_changed()
+
+func _on_color_changed():
+	var material : StandardMaterial3D = $Stem.material_override
+	material.albedo_color = color
+
+func _ready():
+	_on_color_changed()

--- a/scenes/helpers/axis/vector.gd.uid
+++ b/scenes/helpers/axis/vector.gd.uid
@@ -1,0 +1,1 @@
+uid://6ith0ae5jnuy

--- a/scenes/helpers/axis/vector.tscn
+++ b/scenes/helpers/axis/vector.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=5 format=3 uid="uid://cfnu7rw2u32xx"]
+
+[ext_resource type="Script" uid="uid://6ith0ae5jnuy" path="res://scenes/helpers/axis/vector.gd" id="1_dofip"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_dofip"]
+resource_local_to_scene = true
+resource_name = "VectorMaterial"
+shading_mode = 0
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_j8k8m"]
+top_radius = 0.002
+bottom_radius = 0.002
+height = 0.1
+radial_segments = 16
+rings = 0
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_axhod"]
+top_radius = 0.0
+bottom_radius = 0.005
+height = 0.02
+radial_segments = 16
+rings = 0
+cap_top = false
+
+[node name="Vector" type="Node3D"]
+script = ExtResource("1_dofip")
+
+[node name="Stem" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0.05)
+layers = 4
+material_override = SubResource("StandardMaterial3D_dofip")
+cast_shadow = 0
+mesh = SubResource("CylinderMesh_j8k8m")
+
+[node name="Head" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0.11)
+layers = 4
+material_override = SubResource("StandardMaterial3D_dofip")
+cast_shadow = 0
+mesh = SubResource("CylinderMesh_axhod")

--- a/scenes/interactables_demo/interactables_demo.tscn
+++ b/scenes/interactables_demo/interactables_demo.tscn
@@ -29,75 +29,83 @@
 [ext_resource type="PackedScene" uid="uid://dbv1hvxufc1al" path="res://assets/meshes/interactables/push_button.tscn" id="21"]
 [ext_resource type="PackedScene" uid="uid://ca6c2h3xsflxf" path="res://assets/maps/holodeck_map.tscn" id="25_f2g0r"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_bul4v"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_sis4x"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_8kt1f"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_xp3kd"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_2dgfp"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_gcnfp"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_e5jrp"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_aoh21"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_qbsbn"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_oacsx"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_otnhb"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_r6vs4"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_bul4v")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_sis4x")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_8kt1f")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_xp3kd")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_2dgfp")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_gcnfp")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_e5jrp")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_aoh21")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_qbsbn")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_oacsx")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_cnn52"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_c4xim"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_1mlr5"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ylku2"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_wgpq4"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_8a2me"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_i5kg6"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_moq43"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_6131t"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_exmss"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_uouko"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_6vo18"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_cnn52")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_c4xim")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_1mlr5")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_ylku2")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_wgpq4")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_8a2me")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_i5kg6")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_moq43")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_6131t")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_exmss")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
 [node name="InteractablesDemo" instance=ExtResource("1")]
 script = ExtResource("2_a3nc2")
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftPhysicsHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("2_ho402")]
 
+[node name="Hand_Nails_low_L" parent="XROrigin3D/LeftHand/LeftPhysicsHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftPhysicsHand/Hand_Nails_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -118,7 +126,7 @@ bones/22/rotation = Quaternion(0.0585786, 0.0216483, -0.269905, 0.96086)
 bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
 
 [node name="BoneRoot" parent="XROrigin3D/LeftHand/LeftPhysicsHand/Hand_Nails_low_L/Armature/Skeleton3D" index="1"]
-transform = Transform3D(1, -1.83077e-05, 1.52659e-08, 1.52668e-08, 0.00166774, 0.999999, -1.83077e-05, -0.999999, 0.00166774, 3.86425e-08, -1.86975e-05, 0.0271756)
+transform = Transform3D(1, -1.83077e-05, 1.5264e-08, 1.52677e-08, 0.00166774, 0.999999, -1.83077e-05, -0.999999, 0.00166774, 3.86425e-08, -1.86975e-05, 0.0271756)
 
 [node name="BoneThumbMetacarpal" parent="XROrigin3D/LeftHand/LeftPhysicsHand/Hand_Nails_low_L/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, 0.0514604, -0.0176509, -0.017651, 0.613335, 0.789626, 0.0514604, -0.788145, 0.613335, 0.00999954, 0.0200266, 3.59323e-05)
@@ -160,7 +168,7 @@ transform = Transform3D(0.998609, 0.047074, 0.0237409, -0.0169882, -0.138981, 0.
 transform = Transform3D(0.982964, 0.181854, 0.0266582, 0.0109494, -0.202722, 0.979175, 0.183471, -0.962202, -0.20126, -0.00651963, -0.0233502, -0.0731075)
 
 [node name="BoneRingMiddle" parent="XROrigin3D/LeftHand/LeftPhysicsHand/Hand_Nails_low_L/Armature/Skeleton3D" index="15"]
-transform = Transform3D(0.772579, 0.634603, 0.0200164, 0.0794845, -0.127948, 0.98859, 0.629924, -0.762173, -0.149291, 0.000778393, -0.0314857, -0.111722)
+transform = Transform3D(0.772579, 0.634603, 0.0200164, 0.0794845, -0.127948, 0.98859, 0.629924, -0.762173, -0.149291, 0.000778394, -0.0314857, -0.111722)
 
 [node name="BoneRingDistal" parent="XROrigin3D/LeftHand/LeftPhysicsHand/Hand_Nails_low_L/Armature/Skeleton3D" index="16"]
 transform = Transform3D(0.381387, 0.924068, 0.025339, 0.114105, -0.0742599, 0.990689, 0.917346, -0.374945, -0.133762, 0.0184188, -0.0350424, -0.132908)
@@ -188,22 +196,34 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftPhysicsHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_otnhb")
+root_node = NodePath("../Hand_Nails_low_L")
+tree_root = SubResource("AnimationNodeBlendTree_r6vs4")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("3_s2g5l")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("8")]
 strafe = true
 
 [node name="FunctionPickup" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("7")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 ranged_enable = false
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="4" instance=ExtResource("8_rx1lv")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightPhysicsHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("5_x135n")]
 
+[node name="Hand_Nails_low_R" parent="XROrigin3D/RightHand/RightPhysicsHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -224,7 +244,7 @@ bones/22/rotation = Quaternion(0.0585786, -0.0216483, 0.269905, 0.96086)
 bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 
 [node name="BoneRoot" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature/Skeleton3D" index="1"]
-transform = Transform3D(1, 1.83077e-05, -1.52659e-08, -1.52668e-08, 0.00166774, 0.999999, 1.83077e-05, -0.999999, 0.00166774, -3.86425e-08, -1.86975e-05, 0.0271756)
+transform = Transform3D(1, 1.83077e-05, -1.5264e-08, -1.52677e-08, 0.00166774, 0.999999, 1.83077e-05, -0.999999, 0.00166774, -3.86425e-08, -1.86975e-05, 0.0271756)
 
 [node name="BoneThumbMetacarpal" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature/Skeleton3D" index="2"]
 transform = Transform3D(0.998519, -0.0514604, 0.0176509, 0.017651, 0.613335, 0.789626, -0.0514604, -0.788145, 0.613335, -0.00999954, 0.0200266, 3.59323e-05)
@@ -266,10 +286,10 @@ transform = Transform3D(0.998609, -0.047074, -0.0237409, 0.0169882, -0.138981, 0
 transform = Transform3D(0.982964, -0.181854, -0.0266582, -0.0109494, -0.202722, 0.979175, -0.183471, -0.962202, -0.20126, 0.00651963, -0.0233502, -0.0731075)
 
 [node name="BoneRingMiddle" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature/Skeleton3D" index="15"]
-transform = Transform3D(0.772579, -0.634603, -0.0200164, -0.0794844, -0.127948, 0.98859, -0.629924, -0.762173, -0.149291, -0.000778395, -0.0314857, -0.111722)
+transform = Transform3D(0.772579, -0.634603, -0.0200164, -0.0794844, -0.127948, 0.98859, -0.629924, -0.762173, -0.149291, -0.000778396, -0.0314857, -0.111722)
 
 [node name="BoneRingDistal" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature/Skeleton3D" index="16"]
-transform = Transform3D(0.381388, -0.924068, -0.025339, -0.114105, -0.0742599, 0.990689, -0.917346, -0.374945, -0.133762, -0.0184188, -0.0350424, -0.132908)
+transform = Transform3D(0.381387, -0.924068, -0.025339, -0.114105, -0.0742599, 0.990689, -0.917346, -0.374945, -0.133762, -0.0184188, -0.0350424, -0.132908)
 
 [node name="BonePinkyMetacarpal" parent="XROrigin3D/RightHand/RightPhysicsHand/Hand_Nails_low_R/Armature/Skeleton3D" index="17"]
 transform = Transform3D(0.998969, -0.0165318, -0.0422887, 0.0385953, -0.181426, 0.982647, -0.0239172, -0.983265, -0.180601, 4.58211e-07, -0.0299734, 3.59304e-05)
@@ -294,18 +314,22 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightPhysicsHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_uouko")
+root_node = NodePath("../Hand_Nails_low_R")
+tree_root = SubResource("AnimationNodeBlendTree_6vo18")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("3_s2g5l")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("8")]
 
 [node name="MovementTurn" parent="XROrigin3D/RightHand" index="3" instance=ExtResource("10")]
 
 [node name="FunctionPickup" parent="XROrigin3D/RightHand" index="4" instance=ExtResource("7")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 ranged_enable = false
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("11_euqkg")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("9")]
 
@@ -315,7 +339,6 @@ ranged_enable = false
 
 [node name="MainMenuTeleport" parent="." index="2" instance=ExtResource("3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4)
-scene_base = NodePath("..")
 title = ExtResource("4")
 
 [node name="Instructions" parent="." index="3" instance=ExtResource("11_txloh")]

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -42,65 +42,65 @@
 [ext_resource type="Texture2D" uid="uid://cr1l4g7btdyht" path="res://scenes/origin_gravity_demo/origin_gravity_demo.png" id="32_c4n1q"]
 [ext_resource type="Texture2D" uid="uid://dhd30j0xpcxoi" path="res://scenes/sphere_world_demo/sphere_world_demo.png" id="34_xw8ig"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_fhr03"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_d4clr"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_j085u"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ygen5"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ig3ph"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_nk0ku"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_vt8vm"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_cgnj2"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_rl103"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_k3ty7"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_32y8o"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_jtxsw"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_fhr03")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_d4clr")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_j085u")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_ygen5")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_ig3ph")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_nk0ku")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_vt8vm")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_cgnj2")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_rl103")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_k3ty7")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_xw518"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_rkt36"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_f0bph"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_mb0pc"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_s6bkv"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_wky3a"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_emhc7"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_htmm3"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_0xlcy"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_8mn04"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_fkgie"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_5r445"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_xw518")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_rkt36")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_f0bph")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_mb0pc")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_s6bkv")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_wky3a")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_emhc7")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_htmm3")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_0xlcy")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_8mn04")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -118,10 +118,39 @@ color = Color(1, 0, 1, 1)
 [node name="Vignette" parent="XROrigin3D/XRCamera3D" index="3" instance=ExtResource("5_wwfro")]
 auto_inner_radius = 0.5
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("23_pr05t")]
 
+[node name="Hand_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
+[node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_low_L/Armature" index="0"]
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
+bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
+bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
+bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
+bones/6/rotation = Quaternion(0.102925, -0.00993208, -0.00794417, 0.994608)
+bones/7/rotation = Quaternion(-0.012859, -0.0236108, -0.323258, 0.945929)
+bones/8/rotation = Quaternion(0.0120575, -0.00929194, -0.247472, 0.968775)
+bones/10/rotation = Quaternion(-0.0357539, -0.000400032, 0.00636764, 0.99934)
+bones/11/rotation = Quaternion(-0.00264964, -0.00114471, -0.125992, 0.992027)
+bones/12/rotation = Quaternion(0.0394225, 0.00193393, -0.228074, 0.972843)
+bones/13/rotation = Quaternion(-0.0123395, -0.00881294, -0.280669, 0.959685)
+bones/15/rotation = Quaternion(-0.0702656, 0.0101908, -0.0243307, 0.99718)
+bones/16/rotation = Quaternion(-0.0320634, -0.00223624, -0.0686366, 0.997124)
+bones/17/rotation = Quaternion(0.0253452, 0.00812462, -0.249005, 0.968136)
+bones/18/rotation = Quaternion(0.00252232, 0.00788073, -0.243204, 0.96994)
+bones/20/rotation = Quaternion(-0.0917369, 0.0203027, -0.010183, 0.995524)
+bones/21/rotation = Quaternion(-0.0625182, -0.00022572, -0.115393, 0.991351)
+bones/22/rotation = Quaternion(0.0585786, 0.0216483, -0.269905, 0.96086)
+bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
+
 [node name="BoneAttachment3D" type="BoneAttachment3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_low_L/Armature/Skeleton3D" index="1"]
-transform = Transform3D(0.54083, 0.840812, -0.0231736, -0.0826267, 0.0805244, 0.993322, 0.837063, -0.535304, 0.113024, 0.0399019, 0.0402829, -0.150096)
+transform = Transform3D(0.54083, 0.840813, -0.0231736, -0.0826267, 0.0805243, 0.993322, 0.837064, -0.535303, 0.113023, 0.039902, 0.0402828, -0.150096)
 bone_name = "Index_Tip_L"
 bone_idx = 9
 
@@ -129,25 +158,55 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-root_node = NodePath("../Hand_low_L")
-tree_root = SubResource("AnimationNodeBlendTree_32y8o")
+tree_root = SubResource("AnimationNodeBlendTree_jtxsw")
 
-[node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("5_xgcrx")]
+[node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("7_kl172")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
-[node name="MovementDirect" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("6")]
+[node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("5_xgcrx")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="MovementDirect" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("6")]
 strafe = true
-
-[node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("7_kl172")]
 
 [node name="ControlerHider" parent="XROrigin3D/LeftHand" index="4" instance=ExtResource("10_wu0kt")]
 
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("25_2b81d")]
+
+[node name="Hand_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
+[node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_low_R/Armature" index="0"]
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
+bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
+bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
+bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
+bones/6/rotation = Quaternion(0.102925, 0.00993208, 0.00794419, 0.994608)
+bones/7/rotation = Quaternion(-0.012859, 0.0236108, 0.323258, 0.945929)
+bones/8/rotation = Quaternion(0.0120575, 0.00929193, 0.247472, 0.968775)
+bones/10/rotation = Quaternion(-0.0357539, 0.000400032, -0.00636763, 0.99934)
+bones/11/rotation = Quaternion(-0.00264964, 0.00114471, 0.125992, 0.992027)
+bones/12/rotation = Quaternion(0.0394225, -0.00193393, 0.228074, 0.972843)
+bones/13/rotation = Quaternion(-0.0123395, 0.00881294, 0.280669, 0.959685)
+bones/15/rotation = Quaternion(-0.0702656, -0.0101908, 0.0243307, 0.99718)
+bones/16/rotation = Quaternion(-0.0320634, 0.00223624, 0.0686366, 0.997124)
+bones/17/rotation = Quaternion(0.0253452, -0.00812462, 0.249005, 0.968136)
+bones/18/rotation = Quaternion(0.00252233, -0.00788073, 0.243204, 0.96994)
+bones/20/rotation = Quaternion(-0.0917369, -0.0203027, 0.010183, 0.995524)
+bones/21/rotation = Quaternion(-0.0625182, 0.000225721, 0.115393, 0.991351)
+bones/22/rotation = Quaternion(0.0585786, -0.0216483, 0.269905, 0.96086)
+bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 
 [node name="mesh_Hand_low_R" parent="XROrigin3D/RightHand/RightHand/Hand_low_R/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("26_id1x7")
 
 [node name="BoneAttachment3D" type="BoneAttachment3D" parent="XROrigin3D/RightHand/RightHand/Hand_low_R/Armature/Skeleton3D" index="1"]
-transform = Transform3D(0.54083, -0.840812, 0.0231736, 0.0826267, 0.0805244, 0.993322, -0.837063, -0.535304, 0.113024, -0.0399019, 0.0402829, -0.150096)
+transform = Transform3D(0.540829, -0.840813, 0.0231736, 0.0826268, 0.0805242, 0.993322, -0.837064, -0.535303, 0.113024, -0.039902, 0.0402828, -0.150096)
 bone_name = "Index_Tip_R"
 bone_idx = 9
 
@@ -155,16 +214,17 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-root_node = NodePath("../Hand_low_R")
-tree_root = SubResource("AnimationNodeBlendTree_fkgie")
+tree_root = SubResource("AnimationNodeBlendTree_5r445")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("5_xgcrx")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("6")]
 
 [node name="MovementTurn" parent="XROrigin3D/RightHand" index="3" instance=ExtResource("5")]
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="4" instance=ExtResource("12_pwgp0")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="ControlerHider" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("10_wu0kt")]
 
@@ -181,7 +241,6 @@ tree_root = SubResource("AnimationNodeBlendTree_fkgie")
 [node name="MovementDesktopDirect" parent="XROrigin3D" index="8" instance=ExtResource("18_qi05k")]
 
 [node name="MovementDesktopFlight" parent="XROrigin3D" index="9" instance=ExtResource("19_kxx1e")]
-enabled = false
 
 [node name="MovementDesktopJump" parent="XROrigin3D" index="10" instance=ExtResource("20_o61e2")]
 

--- a/scenes/origin_gravity_demo/origin_gravity_demo.tscn
+++ b/scenes/origin_gravity_demo/origin_gravity_demo.tscn
@@ -24,65 +24,65 @@
 [ext_resource type="PackedScene" uid="uid://cyohmj7wut3s8" path="res://scenes/origin_gravity_demo/objects/instructions.tscn" id="19"]
 [ext_resource type="PackedScene" uid="uid://clt88d5d1dje4" path="res://addons/godot-xr-tools/functions/movement_crouch.tscn" id="21"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_1ncao"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_knim5"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_p2lua"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_2gx5h"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ioya3"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_qdik7"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_tmhqs"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_fia44"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_gg3u7"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_qdxbu"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_blqxp"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_c5pn4"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_1ncao")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_knim5")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_p2lua")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_2gx5h")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_ioya3")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_qdik7")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_tmhqs")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_fia44")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_gg3u7")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_qdxbu")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_bn81i"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_doyf2"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ecnxd"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_1ehcp"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_23frg"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_kkrgk"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_e6ev6"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ngltm"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_qjcgd"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_u0nyw"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_msk5t"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_wbt6h"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_bn81i")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_doyf2")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_ecnxd")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_1ehcp")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_23frg")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_kkrgk")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_e6ev6")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_ngltm")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_qjcgd")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_u0nyw")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -107,10 +107,18 @@ script = ExtResource("2_xypqg")
 [node name="XROrigin3D" parent="." index="0"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 36)
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("13")]
 
+[node name="Hand_Nails_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -141,7 +149,8 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_blqxp")
+root_node = NodePath("../Hand_Nails_low_L")
+tree_root = SubResource("AnimationNodeBlendTree_c5pn4")
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("7")]
 strafe = true
@@ -155,11 +164,20 @@ crouch_button_action = "by_button"
 [node name="MovementSprint" parent="XROrigin3D/LeftHand" index="4" instance=ExtResource("15")]
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="5" instance=ExtResource("8_xxyrw")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("14")]
 
+[node name="Hand_Nails_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -190,7 +208,7 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_msk5t")
+tree_root = SubResource("AnimationNodeBlendTree_wbt6h")
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("7")]
 
@@ -203,6 +221,7 @@ jump_button_action = "ax_button"
 controller = 1
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("11_tkwx2")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="MovementFlight" parent="XROrigin3D" index="3" instance=ExtResource("18")]
 
@@ -216,12 +235,10 @@ controller = 1
 
 [node name="Teleport" parent="." index="2" instance=ExtResource("10")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 44)
-scene_base = NodePath("..")
 title = ExtResource("9")
 
 [node name="Teleport2" parent="." index="3" instance=ExtResource("10")]
 transform = Transform3D(-4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0, 1, 10.4, 19, -33)
-scene_base = NodePath("..")
 title = ExtResource("9")
 
 [node name="Instructions" parent="." index="4" instance=ExtResource("19")]
@@ -249,6 +266,7 @@ path_interval_type = 0
 path_interval = 1.0
 path_simplify_angle = 0.0
 path_rotation = 2
+path_rotation_accurate = false
 path_local = false
 path_continuous_u = true
 path_u_distance = 1.0
@@ -271,6 +289,7 @@ path_interval_type = 0
 path_interval = 1.0
 path_simplify_angle = 0.0
 path_rotation = 2
+path_rotation_accurate = false
 path_local = false
 path_continuous_u = true
 path_u_distance = 1.0

--- a/scenes/pickable_demo/objects/grab_ball.tscn
+++ b/scenes/pickable_demo/objects/grab_ball.tscn
@@ -42,7 +42,6 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.19, 0.04, -0.065)
 
 [node name="GrabPointHandRight" parent="." index="1" instance=ExtResource("3_0q4lf")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.19, 0.04, -0.065)
-visible = true
 
 [node name="CollisionShape3D" parent="." index="2"]
 shape = SubResource("2")

--- a/scenes/pickable_demo/pickable_demo.gd
+++ b/scenes/pickable_demo/pickable_demo.gd
@@ -1,3 +1,4 @@
+@tool
 extends DemoSceneBase
 
 @onready var left_hand : XRToolsHand = $XROrigin3D/LeftHand/XRToolsCollisionHand/LeftHand
@@ -6,6 +7,9 @@ extends DemoSceneBase
 @onready var right_ghost_hand : XRToolsHand = $XROrigin3D/RightHand/GhostHand
 
 func _process(_delta):
+	if Engine.is_editor_hint():
+		return
+
 	# Show our ghost hands when when our visible hands aren't where our hands are...
 	if left_hand and left_ghost_hand:
 		var offset = left_hand.global_position - left_ghost_hand.global_position

--- a/scenes/pickable_demo/pickable_demo.tscn
+++ b/scenes/pickable_demo/pickable_demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=48 format=3 uid="uid://0c76wodjd7rm"]
+[gd_scene load_steps=49 format=3 uid="uid://0c76wodjd7rm"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1"]
 [ext_resource type="Script" uid="uid://c80knr3rmwpbr" path="res://scenes/pickable_demo/pickable_demo.gd" id="2_bs8b6"]
@@ -17,6 +17,7 @@
 [ext_resource type="PackedScene" uid="uid://1mb16xioom74" path="res://scenes/pickable_demo/objects/belt_snap_zone.tscn" id="10_5odnk"]
 [ext_resource type="Material" uid="uid://c5jkrtp4eipf4" path="res://scenes/pickable_demo/materials/ghost_hands.tres" id="10_gr6u1"]
 [ext_resource type="PackedScene" uid="uid://cf024hg5alcif" path="res://scenes/pickable_demo/objects/snap_toy_red.tscn" id="11"]
+[ext_resource type="PackedScene" uid="uid://ss6ydhkwbtrl" path="res://scenes/helpers/axis/axis.tscn" id="11_6mq48"]
 [ext_resource type="PackedScene" uid="uid://deyk5frilshws" path="res://assets/meshes/control_pad/control_pad_location_right.tscn" id="11_dk12d"]
 [ext_resource type="PackedScene" uid="uid://cboxrvj4xdi6f" path="res://scenes/pickable_demo/objects/snap_toy_yellow.tscn" id="12"]
 [ext_resource type="PackedScene" uid="uid://ca6c2h3xsflxf" path="res://assets/maps/holodeck_map.tscn" id="12_8rh1y"]
@@ -36,78 +37,86 @@
 [ext_resource type="PackedScene" uid="uid://bmjemjgtnpkpo" path="res://assets/3dmodelscc0/models/scenes/sniper_rifle.tscn" id="25_xgu4l"]
 [ext_resource type="PackedScene" uid="uid://deuxld12hxsq0" path="res://scenes/pickable_demo/objects/picatinny_scope.tscn" id="26_x40vw"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_leov0"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_6mq48"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_tdgjj"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_6148j"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ant8f"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_eva6b"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_baddp"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_lmsso"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_41aoc"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_n45cv"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_8kmfh"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_dfqx6"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_leov0")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_6mq48")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_tdgjj")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_6148j")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_ant8f")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_eva6b")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_baddp")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_lmsso")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_41aoc")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_n45cv")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_8ri27"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_rxqgg"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_oe64k"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_sfixq"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_7sh5g"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_cyqum"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_re3ic"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_l2gui"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_epdw0"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_1jyow"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_x1lgc"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_dqswt"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_8ri27")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_rxqgg")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_oe64k")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_sfixq")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_7sh5g")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_cyqum")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_re3ic")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_l2gui")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_epdw0")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_1jyow")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
 [node name="PickableDemo" instance=ExtResource("1")]
 script = ExtResource("2_bs8b6")
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="XRToolsCollisionHand" parent="XROrigin3D/LeftHand" index="0" node_paths=PackedStringArray("hand_skeleton") instance=ExtResource("3_m7tr4")]
 hand_skeleton = NodePath("LeftHand/Hand_Nails_low_L/Armature/Skeleton3D")
 
 [node name="LeftHand" parent="XROrigin3D/LeftHand/XRToolsCollisionHand" index="0" instance=ExtResource("7_ywaf6")]
 
+[node name="Hand_Nails_low_L" parent="XROrigin3D/LeftHand/XRToolsCollisionHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/XRToolsCollisionHand/LeftHand/Hand_Nails_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -139,28 +148,42 @@ push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/XRToolsCollisionHand/LeftHand" index="1"]
 root_node = NodePath("../Hand_Nails_low_L")
-tree_root = SubResource("AnimationNodeBlendTree_8kmfh")
+tree_root = SubResource("AnimationNodeBlendTree_dfqx6")
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand/XRToolsCollisionHand" index="1" instance=ExtResource("7")]
 strafe = true
 
 [node name="FunctionPickup" parent="XROrigin3D/LeftHand/XRToolsCollisionHand" index="2" instance=ExtResource("8")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 grab_distance = 0.1
 ranged_angle = 10.0
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand/XRToolsCollisionHand" index="3" instance=ExtResource("7_fdgf8")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="GhostHand" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("7_ywaf6")]
 visible = false
 hand_material_override = ExtResource("10_gr6u1")
+
+[node name="LeftHandAxis" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("11_6mq48")]
+visible = false
+label = "   LeftHand"
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="XRToolsCollisionHand" parent="XROrigin3D/RightHand" index="0" node_paths=PackedStringArray("hand_skeleton") instance=ExtResource("3_m7tr4")]
 hand_skeleton = NodePath("RightHand/Hand_Nails_R/Armature/Skeleton3D")
 
 [node name="RightHand" parent="XROrigin3D/RightHand/XRToolsCollisionHand" index="0" instance=ExtResource("9_v8epv")]
 
+[node name="Hand_Nails_R" parent="XROrigin3D/RightHand/XRToolsCollisionHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/XRToolsCollisionHand/RightHand/Hand_Nails_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -192,25 +215,33 @@ push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/XRToolsCollisionHand/RightHand" index="1"]
 root_node = NodePath("../Hand_Nails_R")
-tree_root = SubResource("AnimationNodeBlendTree_x1lgc")
+tree_root = SubResource("AnimationNodeBlendTree_dqswt")
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand/XRToolsCollisionHand" index="1" instance=ExtResource("7")]
 
 [node name="MovementTurn" parent="XROrigin3D/RightHand/XRToolsCollisionHand" index="2" instance=ExtResource("10")]
 
 [node name="FunctionPickup" parent="XROrigin3D/RightHand/XRToolsCollisionHand" index="3" instance=ExtResource("8")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 grab_distance = 0.1
 ranged_angle = 10.0
 
 [node name="FunctionPointer" parent="XROrigin3D/RightHand/XRToolsCollisionHand" index="4" instance=ExtResource("7_kskan")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.02, -0.0353553, -0.106066)
 show_laser = 2
 laser_length = 1
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand/XRToolsCollisionHand" index="5" instance=ExtResource("11_dk12d")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="GhostHand" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("15_v4ej7")]
 visible = false
 hand_material_override = ExtResource("10_gr6u1")
+
+[node name="RightHandAxis" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("11_6mq48")]
+transform = Transform3D(0.75, 0, 0, 0, 0.75, 0, 0, 0, 0.75, 0, 0, 0)
+visible = false
+label = "        RightHand"
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("9")]
 

--- a/scenes/pointer_demo/pointer_demo.tscn
+++ b/scenes/pointer_demo/pointer_demo.tscn
@@ -23,65 +23,65 @@
 [ext_resource type="PackedScene" uid="uid://ct3p5sgwvkmva" path="res://assets/meshes/control_pad/control_pad.tscn" id="12_yae1p"]
 [ext_resource type="PackedScene" uid="uid://bk34216s7eynw" path="res://scenes/pointer_demo/objects/color_change_cube.tscn" id="15"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_52604"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_edtqg"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_y82s1"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ieoyi"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_17ope"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ym1fd"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_f44mv"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_g20d3"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_p755d"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_17y45"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_phxai"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_ftkhu"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_52604")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_edtqg")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_y82s1")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_ieoyi")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_17ope")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_ym1fd")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_f44mv")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_g20d3")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_p755d")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_17y45")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_w3q17"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_fevuq"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_858io"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_icax2"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_jqj0l"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_jkndr"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ski4q"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_mwu1r"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_1lh7b"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ijbl6"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_sve7d"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_d28ca"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_w3q17")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_fevuq")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_858io")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_icax2")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_jqj0l")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_jkndr")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_ski4q")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_mwu1r")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_1lh7b")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_ijbl6")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -92,10 +92,18 @@ script = ExtResource("2_pbiwr")
 click_on_hold = true
 color = Color(1, 0, 1, 1)
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("3_j5kt2")]
 
+[node name="Hand_Nails_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -127,14 +135,16 @@ push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
 root_node = NodePath("../Hand_Nails_low_L")
-tree_root = SubResource("AnimationNodeBlendTree_phxai")
+tree_root = SubResource("AnimationNodeBlendTree_ftkhu")
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("7")]
 strafe = true
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("6_omyut")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="FunctionPointer" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("5")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.02, -0.0353553, -0.106066)
 show_laser = 2
 laser_length = 1
 laser_material = ExtResource("8_8kxbu")
@@ -143,10 +153,18 @@ show_target = true
 target_radius = 0.01
 target_material = ExtResource("10_fxi5i")
 
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("6_rnrhb")]
 
+[node name="Hand_Nails_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -177,16 +195,17 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-root_node = NodePath("../Hand_Nails_low_R")
-tree_root = SubResource("AnimationNodeBlendTree_sve7d")
+tree_root = SubResource("AnimationNodeBlendTree_d28ca")
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("7")]
 
 [node name="MovementTurn" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("9")]
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="3" instance=ExtResource("9_qbaa8")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="FunctionPointer" parent="XROrigin3D/RightHand" index="4" instance=ExtResource("5")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.02, -0.0353553, -0.106066)
 show_laser = 2
 laser_length = 1
 laser_material = ExtResource("8_8kxbu")

--- a/scenes/poke_demo/poke_demo.tscn
+++ b/scenes/poke_demo/poke_demo.tscn
@@ -24,65 +24,65 @@
 [ext_resource type="Resource" uid="uid://ciw0f7mg4ai0k" path="res://addons/godot-xr-tools/hands/poses/pose_point_left.tres" id="15_08yhv"]
 [ext_resource type="Resource" uid="uid://bhvrpfo4ecbub" path="res://addons/godot-xr-tools/hands/poses/pose_point_right.tres" id="16_n1x7k"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_xl1gi"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ivb75"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_6gubm"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_vld8a"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_7tsba"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ah5ef"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_auv36"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_aie25"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_g6blh"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_a7nh1"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_66tfg"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_2xhdm"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_xl1gi")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_ivb75")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_6gubm")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_vld8a")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_7tsba")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_ah5ef")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_auv36")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_aie25")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_g6blh")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_a7nh1")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_aac8g"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_jiur4"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_fghgc"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_dotjg"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_l0pin"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_068d6"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_m7ghb"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_flupp"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_wdvjc"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_lcjit"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_kx4vt"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_navyh"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_aac8g")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_jiur4")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_fghgc")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_dotjg")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_l0pin")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_068d6")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_m7ghb")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_flupp")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_wdvjc")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_lcjit")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -92,10 +92,18 @@ size = Vector3(1, 0.5, 0.01)
 [node name="PokeDemo" instance=ExtResource("1")]
 script = ExtResource("2_sgf8o")
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("3")]
 
+[node name="Hand_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -124,19 +132,29 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_66tfg")
+tree_root = SubResource("AnimationNodeBlendTree_2xhdm")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("4_whmmd")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("11")]
 strafe = true
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("7_2052r")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("2")]
 
+[node name="Hand_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -165,15 +183,17 @@ bone_idx = 9
 transform = Transform3D(0.999999, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_kx4vt")
+tree_root = SubResource("AnimationNodeBlendTree_navyh")
 
 [node name="FunctionPoseDetector" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("4_whmmd")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("11")]
 
 [node name="MovementTurn" parent="XROrigin3D/RightHand" index="3" instance=ExtResource("14")]
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="4" instance=ExtResource("10_3s3jo")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("10")]
 
@@ -183,7 +203,6 @@ tree_root = SubResource("AnimationNodeBlendTree_kx4vt")
 
 [node name="Teleport" parent="." index="2" instance=ExtResource("5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4)
-scene_base = NodePath("..")
 title = ExtResource("6")
 
 [node name="Instructions" parent="." index="3" instance=ExtResource("11_570m5")]
@@ -196,6 +215,8 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2, -1.581)
 screen_size = Vector2(1, 0.5)
 scene = ExtResource("9")
 viewport_size = Vector2(1000, 500)
+transparent = 1
+scene_properties_keys = PackedStringArray("canvas.gd")
 
 [node name="HandPoseArea" parent="PokeCanvas" index="1" instance=ExtResource("14_qyy11")]
 left_pose = ExtResource("15_08yhv")

--- a/scenes/rumble_demo/rumble_demo.tscn
+++ b/scenes/rumble_demo/rumble_demo.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=45 format=3 uid="uid://cgt8gtl7scueq"]
+[gd_scene load_steps=43 format=3 uid="uid://cgt8gtl7scueq"]
 
 [ext_resource type="PackedScene" uid="uid://qbmx03iibuuu" path="res://addons/godot-xr-tools/staging/scene_base.tscn" id="1_addaq"]
 [ext_resource type="PackedScene" uid="uid://b4kad2kuba1yn" path="res://addons/godot-xr-tools/hands/scenes/lowpoly/left_hand_low.tscn" id="1_hxlll"]
@@ -23,7 +23,6 @@
 [ext_resource type="Resource" uid="uid://5sa0r2bvv18q" path="res://scenes/rumble_demo/resources/left_by_rumble.tres" id="16_js7sl"]
 [ext_resource type="Resource" uid="uid://b8ltclufuevvk" path="res://scenes/rumble_demo/resources/right_ax_rumble.tres" id="20_2cj4t"]
 [ext_resource type="PackedScene" uid="uid://dhysdwgk0bu8b" path="res://scenes/rumble_demo/objects/instructions.tscn" id="20_kdrn5"]
-[ext_resource type="Script" uid="uid://b15qba0ch13uw" path="res://addons/godot-xr-tools/rumble/rumble_event.gd" id="20_y7okn"]
 [ext_resource type="PackedScene" uid="uid://cqcuhdwpar4ju" path="res://scenes/rumble_demo/objects/rumble_area.tscn" id="21_4wwyr"]
 [ext_resource type="Resource" uid="uid://csfn7atwtdh8b" path="res://scenes/rumble_demo/resources/right_by_rumble.tres" id="21_ojajd"]
 [ext_resource type="Resource" uid="uid://dwbxd6cc7oae2" path="res://scenes/rumble_demo/resources/indefinite/rumble_strength_1.tres" id="24_cqao3"]
@@ -32,72 +31,65 @@
 [ext_resource type="Resource" uid="uid://ciaadhp4w7aoc" path="res://scenes/rumble_demo/resources/indefinite/rumble_strength_4.tres" id="27_6updc"]
 [ext_resource type="Resource" uid="uid://cd5kwyv8adclo" path="res://scenes/rumble_demo/resources/indefinite/rumble_strength_5.tres" id="28_r18ed"]
 
-[sub_resource type="Resource" id="Resource_afmdc"]
-script = ExtResource("20_y7okn")
-magnitude = 0.2
-active_during_pause = false
-indefinite = false
-duration_ms = 300
-
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_0suwp"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_231la"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_if0fp"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_4k72y"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_phboq"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_lqpq4"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_i1h7y"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_q7pai"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_tsppl"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_xfgy1"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_vhw5m"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_fq45g"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_0suwp")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_231la")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_if0fp")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_4k72y")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_phboq")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_lqpq4")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_i1h7y")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_q7pai")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_tsppl")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_xfgy1")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_q1mc1"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_d5wpo"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_rotsw"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_k577i"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_d7iaq"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_md7qr"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_wohuv"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_vwjbd"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_iu5e5"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_yvfl2"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_pqgfg"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_b4qyc"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_q1mc1")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_d5wpo")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_rotsw")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_k577i")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_d7iaq")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_md7qr")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_wohuv")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_vwjbd")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_iu5e5")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_yvfl2")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -108,14 +100,21 @@ node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigge
 [node name="XRToolsRumbleManager" type="Node" parent="XROrigin3D" index="1"]
 process_mode = 3
 script = ExtResource("15_dkfqx")
-wakeup_rumble = SubResource("Resource_afmdc")
 
 [node name="ControlPad" parent="XROrigin3D" index="2" instance=ExtResource("13_cnmv7")]
 
+[node name="LeftHand" parent="XROrigin3D" index="4"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("1_hxlll")]
 
+[node name="Hand_Nails_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -146,14 +145,17 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_vhw5m")
+root_node = NodePath("../Hand_Nails_low_L")
+tree_root = SubResource("AnimationNodeBlendTree_fq45g")
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("3_l0y3a")]
 strafe = true
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("4_obmql")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="FunctionPointer" parent="XROrigin3D/LeftHand" index="3" instance=ExtResource("5_f6t3b")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.02, -0.0353553, -0.106066)
 show_laser = 2
 laser_length = 1
 laser_material = ExtResource("6_s2fv7")
@@ -167,10 +169,18 @@ script = ExtResource("13_8lb5g")
 ax_button_event = ExtResource("15_cjtso")
 by_button_event = ExtResource("16_js7sl")
 
+[node name="RightHand" parent="XROrigin3D" index="5"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("9_s4p3g")]
 
+[node name="Hand_Nails_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -201,15 +211,17 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_pqgfg")
+tree_root = SubResource("AnimationNodeBlendTree_b4qyc")
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("3_l0y3a")]
 
 [node name="MovementTurn" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("10_vw0xv")]
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="3" instance=ExtResource("11_5usl5")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="FunctionPointer" parent="XROrigin3D/RightHand" index="4" instance=ExtResource("5_f6t3b")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.02, -0.0353553, -0.106066)
 show_laser = 2
 laser_length = 1
 laser_material = ExtResource("6_s2fv7")
@@ -228,9 +240,6 @@ by_button_event = ExtResource("21_ojajd")
 [node name="Teleport" parent="." index="2" instance=ExtResource("15_djcf4")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4)
 title = ExtResource("16_h8o41")
-spawn_point_name = ""
-spawn_point_position = Vector3(0, 0, 0)
-spawn_point_transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="Instructions" parent="." index="3" instance=ExtResource("20_kdrn5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, -4.984)

--- a/scenes/sphere_world_demo/sphere_world_demo.tscn
+++ b/scenes/sphere_world_demo/sphere_world_demo.tscn
@@ -30,65 +30,65 @@
 [ext_resource type="PackedScene" uid="uid://bu7s5v5ygr0aa" path="res://scenes/sphere_world_demo/objects/donut.tscn" id="23_nox6a"]
 [ext_resource type="PackedScene" uid="uid://cutuj4o2r75tg" path="res://scenes/sphere_world_demo/objects/tower.tscn" id="24"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_qcqau"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_bxet1"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_51gwd"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_bqf7n"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_fd23s"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_gs0nd"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_vv358"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_xn8ib"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_cqvvu"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_q810u"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_uwsp2"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_8v0vk"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_qcqau")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_bxet1")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_51gwd")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_bqf7n")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_fd23s")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_gs0nd")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_vv358")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_xn8ib")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_cqvvu")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_q810u")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_h1uox"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_72hod"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_y11tb"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_3cwsw"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_5traq"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_hadlu"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_xsit7"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_u5c3v"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_rawop"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_5tcs6"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_lp4qd"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_j5gj6"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_h1uox")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_72hod")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_y11tb")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_3cwsw")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_5traq")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_hadlu")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_xsit7")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_u5c3v")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_rawop")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_5tcs6")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -112,11 +112,19 @@ environment = ExtResource("19")
 [node name="XROrigin3D" parent="." index="1"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 50, 0)
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("4")]
 hand_material_override = ExtResource("4_3wr22")
 
+[node name="Hand_Glove_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_Glove_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -150,9 +158,11 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_uwsp2")
+root_node = NodePath("../Hand_Glove_low_L")
+tree_root = SubResource("AnimationNodeBlendTree_8v0vk")
 
 [node name="FunctionPickup" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("8")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 ranged_enable = false
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("5")]
@@ -167,12 +177,21 @@ jump_button_action = "ax_button"
 crouch_button_action = "by_button"
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="6" instance=ExtResource("12_wdnff")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("10")]
 hand_material_override = ExtResource("4_3wr22")
 
+[node name="Hand_Glove_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_Glove_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -205,9 +224,11 @@ layer = 0
 mask = 4194304
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_lp4qd")
+root_node = NodePath("../Hand_Glove_low_R")
+tree_root = SubResource("AnimationNodeBlendTree_j5gj6")
 
 [node name="FunctionPickup" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("8")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 ranged_enable = false
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("5")]
@@ -218,9 +239,11 @@ ranged_enable = false
 jump_button_action = "ax_button"
 
 [node name="MovementGrapple" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("11")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 grapple_collision_mask = 3
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="6" instance=ExtResource("16_k5a7v")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("3")]
 
@@ -236,22 +259,18 @@ grapple_collision_mask = 3
 
 [node name="Teleport1" parent="." index="2" instance=ExtResource("20")]
 transform = Transform3D(-4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0, 1, 49.9, 0, 0)
-scene_base = NodePath("..")
 title = ExtResource("21")
 
 [node name="Teleport2" parent="." index="3" instance=ExtResource("20")]
 transform = Transform3D(1.91069e-15, -4.37114e-08, 1, -1, -4.37114e-08, 0, 4.37114e-08, -1, -4.37114e-08, 0, 0, -49.9)
-scene_base = NodePath("..")
 title = ExtResource("21")
 
 [node name="Teleport3" parent="." index="4" instance=ExtResource("20")]
 transform = Transform3D(4.37114e-08, -1, -8.74228e-08, -1, -4.37114e-08, 0, -3.82137e-15, 8.74228e-08, -1, -49.9, 0, 0)
-scene_base = NodePath("..")
 title = ExtResource("21")
 
 [node name="Teleport4" parent="." index="5" instance=ExtResource("20")]
 transform = Transform3D(-5.73206e-15, 1.31134e-07, -1, -1, -4.37114e-08, 0, -4.37114e-08, 1, 1.31134e-07, 0, 0, 49.9)
-scene_base = NodePath("..")
 title = ExtResource("21")
 
 [node name="World" type="Node3D" parent="." index="6"]

--- a/scenes/sprinting_demo/sprinting_demo.tscn
+++ b/scenes/sprinting_demo/sprinting_demo.tscn
@@ -26,65 +26,65 @@
 [ext_resource type="PackedScene" uid="uid://chcuj3jysipk8" path="res://addons/godot-xr-tools/functions/movement_jog.tscn" id="18_56ii6"]
 [ext_resource type="PackedScene" uid="uid://d2bvjxai7dke8" path="res://scenes/sprinting_demo/objects/instructions.tscn" id="19"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_xf318"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ult38"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_1tow8"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_cswe1"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_0jrkh"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_yohqo"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_sf0fw"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_rypfw"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_rd468"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_3vunt"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_8smne"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_g73uq"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_xf318")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_ult38")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_1tow8")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_cswe1")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_0jrkh")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_yohqo")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_sf0fw")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_rypfw")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_rd468")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_3vunt")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_36rmm"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_7vm83"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_w23ug"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_g6cvx"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ddce6"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_f34h8"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_fyr3e"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_w3pbo"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_pfr6v"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_6dvuk"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_n7rlj"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_fs65r"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_36rmm")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_7vm83")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_w23ug")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_g6cvx")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_ddce6")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_f34h8")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_fyr3e")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_w3pbo")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_pfr6v")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_6dvuk")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -99,8 +99,37 @@ point_count = 7
 [node name="SprintingDemo" instance=ExtResource("6")]
 script = ExtResource("2_5a8oj")
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("7")]
 hand_material_override = ExtResource("12")
+
+[node name="Hand_Nails_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
+[node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L/Armature" index="0"]
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
+bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
+bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
+bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
+bones/6/rotation = Quaternion(0.102925, -0.00993208, -0.00794417, 0.994608)
+bones/7/rotation = Quaternion(-0.012859, -0.0236108, -0.323258, 0.945929)
+bones/8/rotation = Quaternion(0.0120575, -0.00929194, -0.247472, 0.968775)
+bones/10/rotation = Quaternion(-0.0357539, -0.000400032, 0.00636764, 0.99934)
+bones/11/rotation = Quaternion(-0.00264964, -0.00114471, -0.125992, 0.992027)
+bones/12/rotation = Quaternion(0.0394225, 0.00193393, -0.228074, 0.972843)
+bones/13/rotation = Quaternion(-0.0123395, -0.00881294, -0.280669, 0.959685)
+bones/15/rotation = Quaternion(-0.0702656, 0.0101908, -0.0243307, 0.99718)
+bones/16/rotation = Quaternion(-0.0320634, -0.00223624, -0.0686366, 0.997124)
+bones/17/rotation = Quaternion(0.0253452, 0.00812462, -0.249005, 0.968136)
+bones/18/rotation = Quaternion(0.00252232, 0.00788073, -0.243204, 0.96994)
+bones/20/rotation = Quaternion(-0.0917369, 0.0203027, -0.010183, 0.995524)
+bones/21/rotation = Quaternion(-0.0625182, -0.00022572, -0.115393, 0.991351)
+bones/22/rotation = Quaternion(0.0585786, 0.0216483, -0.269905, 0.96086)
+bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
 
 [node name="mesh_Hand_Nails_low_L" parent="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L/Armature/Skeleton3D" index="0"]
 material_override = ExtResource("12")
@@ -113,9 +142,11 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_8smne")
+root_node = NodePath("../Hand_Nails_low_L")
+tree_root = SubResource("AnimationNodeBlendTree_g73uq")
 
 [node name="FunctionPickup" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("10")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 grab_distance = 0.1
 
 [node name="MovementDirect" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("11")]
@@ -127,15 +158,45 @@ jump_button_action = "ax_button"
 [node name="MovementSprint" parent="XROrigin3D/LeftHand" index="4" instance=ExtResource("8")]
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="5" instance=ExtResource("10_vwnp8")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("9")]
 hand_material_override = ExtResource("12")
+
+[node name="Hand_Nails_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
+[node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R/Armature" index="0"]
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
+bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
+bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
+bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
+bones/6/rotation = Quaternion(0.102925, 0.00993208, 0.00794419, 0.994608)
+bones/7/rotation = Quaternion(-0.012859, 0.0236108, 0.323258, 0.945929)
+bones/8/rotation = Quaternion(0.0120575, 0.00929193, 0.247472, 0.968775)
+bones/10/rotation = Quaternion(-0.0357539, 0.000400032, -0.00636763, 0.99934)
+bones/11/rotation = Quaternion(-0.00264964, 0.00114471, 0.125992, 0.992027)
+bones/12/rotation = Quaternion(0.0394225, -0.00193393, 0.228074, 0.972843)
+bones/13/rotation = Quaternion(-0.0123395, 0.00881294, 0.280669, 0.959685)
+bones/15/rotation = Quaternion(-0.0702656, -0.0101908, 0.0243307, 0.99718)
+bones/16/rotation = Quaternion(-0.0320634, 0.00223624, 0.0686366, 0.997124)
+bones/17/rotation = Quaternion(0.0253452, -0.00812462, 0.249005, 0.968136)
+bones/18/rotation = Quaternion(0.00252233, -0.00788073, 0.243204, 0.96994)
+bones/20/rotation = Quaternion(-0.0917369, -0.0203027, 0.010183, 0.995524)
+bones/21/rotation = Quaternion(-0.0625182, 0.000225721, 0.115393, 0.991351)
+bones/22/rotation = Quaternion(0.0585786, -0.0216483, 0.269905, 0.96086)
+bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 
 [node name="mesh_Hand_Nails_low_R" parent="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R/Armature/Skeleton3D" index="0"]
 material_override = ExtResource("12")
 
 [node name="BoneAttachment3D" type="BoneAttachment3D" parent="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R/Armature/Skeleton3D" index="1"]
-transform = Transform3D(0.54083, -0.840812, 0.0231736, 0.0826267, 0.0805244, 0.993322, -0.837063, -0.535304, 0.113024, -0.0399019, 0.0402829, -0.150096)
+transform = Transform3D(0.540829, -0.840813, 0.0231736, 0.0826268, 0.0805242, 0.993322, -0.837064, -0.535303, 0.113024, -0.039902, 0.0402828, -0.150096)
 bone_name = "Index_Tip_R"
 bone_idx = 9
 
@@ -144,9 +205,10 @@ layer = 0
 mask = 4194304
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_n7rlj")
+tree_root = SubResource("AnimationNodeBlendTree_fs65r")
 
 [node name="FunctionPickup" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("10")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 grab_distance = 0.1
 
 [node name="MovementDirect" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("11")]
@@ -157,6 +219,7 @@ grab_distance = 0.1
 jump_button_action = "ax_button"
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="5" instance=ExtResource("13_fes4q")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("17_k8kqb")]
 physics = ExtResource("12_ureyg")
@@ -174,9 +237,6 @@ fast_speed = 6.0
 [node name="Teleport" parent="." index="2" instance=ExtResource("15")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20, 0, 0)
 title = ExtResource("14")
-spawn_point_name = ""
-spawn_point_position = Vector3(0, 0, 0)
-spawn_point_transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="Instructions" parent="." index="3" instance=ExtResource("19")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, -4)
@@ -197,6 +257,7 @@ path_interval_type = 0
 path_interval = 2.0
 path_simplify_angle = 0.0
 path_rotation = 2
+path_rotation_accurate = false
 path_local = false
 path_continuous_u = true
 path_u_distance = 1.0

--- a/scenes/teleport_demo/teleport_demo.tscn
+++ b/scenes/teleport_demo/teleport_demo.tscn
@@ -21,65 +21,65 @@
 [ext_resource type="Script" uid="uid://153oneb2r3uq" path="res://addons/godot-xr-tools/objects/teleport_area.gd" id="19_ir3h8"]
 [ext_resource type="PackedScene" uid="uid://2j2ufl3svgcl" path="res://scenes/teleport_demo/objects/teleport_area_end.tscn" id="20_r3e3h"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_o1482"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_hli5e"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_twfgb"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_6bdyh"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_tsoy3"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_sf5fp"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_16v2u"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_vwra8"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_cbte8"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ghegr"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_rrxmv"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_m37q4"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_o1482")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_hli5e")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_twfgb")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_6bdyh")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_tsoy3")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_sf5fp")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_16v2u")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_vwra8")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_cbte8")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_ghegr")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_pgwaj"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_nf7kt"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_gmu5c"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_dmojc"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ixyki"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_kthvf"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_kesst"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_xxnr8"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_xe4rd"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_0h5in"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_dhr02"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_jrboq"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_pgwaj")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_nf7kt")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_gmu5c")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_dmojc")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_ixyki")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_kthvf")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_kesst")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_xxnr8")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_xe4rd")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_0h5in")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -90,10 +90,18 @@ radius = 0.9
 [node name="TeleportDemo" instance=ExtResource("1")]
 script = ExtResource("2_sq0a2")
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("3_f75tv")]
 
+[node name="Hand_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -124,16 +132,26 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_rrxmv")
+tree_root = SubResource("AnimationNodeBlendTree_m37q4")
 
 [node name="FunctionTeleport" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("2")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, -0.0707107, -0.0707107)
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("6_ccpk6")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("7_1ild1")]
 
+[node name="Hand_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -164,11 +182,12 @@ mask = 4194304
 push_bodies = false
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_dhr02")
+tree_root = SubResource("AnimationNodeBlendTree_jrboq")
 
 [node name="MovementTurn" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("5")]
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("9_5ab7n")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="PlayerBody" parent="XROrigin3D" index="3" instance=ExtResource("4")]
 
@@ -179,9 +198,6 @@ tree_root = SubResource("AnimationNodeBlendTree_dhr02")
 [node name="MainMenuTeleport" parent="." index="2" instance=ExtResource("6")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 7)
 title = ExtResource("3")
-spawn_point_name = ""
-spawn_point_position = Vector3(0, 0, 0)
-spawn_point_transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="Instructions" parent="." index="3" instance=ExtResource("8_s8lss")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, -4)
@@ -194,7 +210,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7, 0, 0)
 
 [node name="TeleportAreaStart" parent="." index="6" instance=ExtResource("18_jaum3")]
 
-[node name="XRToolsTeleportArea2" type="Area3D" parent="TeleportAreaStart" index="3" node_paths=PackedStringArray("target")]
+[node name="XRToolsTeleportArea2" type="Area3D" parent="TeleportAreaStart" index="2" node_paths=PackedStringArray("target")]
 collision_layer = 0
 collision_mask = 524288
 script = ExtResource("19_ir3h8")
@@ -206,7 +222,7 @@ shape = SubResource("CylinderShape3D_tsup4")
 
 [node name="TeleportAreaEnd" parent="." index="7" instance=ExtResource("20_r3e3h")]
 
-[node name="TeleportTarget" type="Marker3D" parent="TeleportAreaEnd" index="3"]
+[node name="TeleportTarget" type="Marker3D" parent="TeleportAreaEnd" index="2"]
 transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 0.1, 0)
 
 [editable path="XROrigin3D/LeftHand/LeftHand"]

--- a/scenes/world_grab_demo/world_grab_demo.tscn
+++ b/scenes/world_grab_demo/world_grab_demo.tscn
@@ -20,65 +20,65 @@
 [ext_resource type="PackedScene" uid="uid://d3x7ha0qme5uv" path="res://scenes/world_grab_demo/objects/arena_cylinder.tscn" id="15_ghqx0"]
 [ext_resource type="PackedScene" uid="uid://v1ajdy8xxct3" path="res://scenes/world_grab_demo/objects/arena_wall.tscn" id="16_bar6p"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_fmn03"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_5rl45"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_1x2be"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ndlrj"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_0da3y"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_wmxff"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_L", "Armature/Skeleton3D:Little_Intermediate_L", "Armature/Skeleton3D:Little_Metacarpal_L", "Armature/Skeleton3D:Little_Proximal_L", "Armature/Skeleton3D:Middle_Distal_L", "Armature/Skeleton3D:Middle_Intermediate_L", "Armature/Skeleton3D:Middle_Metacarpal_L", "Armature/Skeleton3D:Middle_Proximal_L", "Armature/Skeleton3D:Ring_Distal_L", "Armature/Skeleton3D:Ring_Intermediate_L", "Armature/Skeleton3D:Ring_Metacarpal_L", "Armature/Skeleton3D:Ring_Proximal_L", "Armature/Skeleton3D:Thumb_Distal_L", "Armature/Skeleton3D:Thumb_Metacarpal_L", "Armature/Skeleton3D:Thumb_Proximal_L", "Armature/Skeleton:Little_Distal_L", "Armature/Skeleton:Little_Intermediate_L", "Armature/Skeleton:Little_Proximal_L", "Armature/Skeleton:Middle_Distal_L", "Armature/Skeleton:Middle_Intermediate_L", "Armature/Skeleton:Middle_Proximal_L", "Armature/Skeleton:Ring_Distal_L", "Armature/Skeleton:Ring_Intermediate_L", "Armature/Skeleton:Ring_Proximal_L", "Armature/Skeleton:Thumb_Distal_L", "Armature/Skeleton:Thumb_Proximal_L"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_wj27r"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_aycwm"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_7e2a6"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_lelvd"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_L", "Armature/Skeleton3D:Index_Intermediate_L", "Armature/Skeleton3D:Index_Metacarpal_L", "Armature/Skeleton3D:Index_Proximal_L", "Armature/Skeleton:Index_Distal_L", "Armature/Skeleton:Index_Intermediate_L", "Armature/Skeleton:Index_Proximal_L"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_m26jc"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_nnm50"]
 graph_offset = Vector2(-536, 11)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_fmn03")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_5rl45")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_1x2be")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_ndlrj")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_0da3y")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_wmxff")
 nodes/Grip/position = Vector2(0, 20)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_wj27r")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_aycwm")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_7e2a6")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_lelvd")
 nodes/Trigger/position = Vector2(-360, 20)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_2m0xq"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_wlbkw"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_ejvd7"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_lpnlu"]
 animation = &"Grip"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_ti4n2"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_5q6cm"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Little_Distal_R", "Armature/Skeleton3D:Little_Intermediate_R", "Armature/Skeleton3D:Little_Metacarpal_R", "Armature/Skeleton3D:Little_Proximal_R", "Armature/Skeleton3D:Middle_Distal_R", "Armature/Skeleton3D:Middle_Intermediate_R", "Armature/Skeleton3D:Middle_Metacarpal_R", "Armature/Skeleton3D:Middle_Proximal_R", "Armature/Skeleton3D:Ring_Distal_R", "Armature/Skeleton3D:Ring_Intermediate_R", "Armature/Skeleton3D:Ring_Metacarpal_R", "Armature/Skeleton3D:Ring_Proximal_R", "Armature/Skeleton3D:Thumb_Distal_R", "Armature/Skeleton3D:Thumb_Metacarpal_R", "Armature/Skeleton3D:Thumb_Proximal_R", "Armature/Skeleton:Little_Distal_R", "Armature/Skeleton:Little_Intermediate_R", "Armature/Skeleton:Little_Proximal_R", "Armature/Skeleton:Middle_Distal_R", "Armature/Skeleton:Middle_Intermediate_R", "Armature/Skeleton:Middle_Proximal_R", "Armature/Skeleton:Ring_Distal_R", "Armature/Skeleton:Ring_Intermediate_R", "Armature/Skeleton:Ring_Proximal_R", "Armature/Skeleton:Thumb_Distal_R", "Armature/Skeleton:Thumb_Proximal_R"]
 
-[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_djme2"]
+[sub_resource type="AnimationNodeAnimation" id="AnimationNodeAnimation_emwdi"]
 animation = &"Grip 5"
 
-[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_2oo4h"]
+[sub_resource type="AnimationNodeBlend2" id="AnimationNodeBlend2_0neuw"]
 filter_enabled = true
 filters = ["Armature/Skeleton3D:Index_Distal_R", "Armature/Skeleton3D:Index_Intermediate_R", "Armature/Skeleton3D:Index_Metacarpal_R", "Armature/Skeleton3D:Index_Proximal_R", "Armature/Skeleton:Index_Distal_R", "Armature/Skeleton:Index_Intermediate_R", "Armature/Skeleton:Index_Proximal_R"]
 
-[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_g51po"]
+[sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_f5g0g"]
 graph_offset = Vector2(-552.664, 107.301)
-nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_2m0xq")
+nodes/ClosedHand1/node = SubResource("AnimationNodeAnimation_wlbkw")
 nodes/ClosedHand1/position = Vector2(-600, 300)
-nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_ejvd7")
+nodes/ClosedHand2/node = SubResource("AnimationNodeAnimation_lpnlu")
 nodes/ClosedHand2/position = Vector2(-360, 300)
-nodes/Grip/node = SubResource("AnimationNodeBlend2_ti4n2")
+nodes/Grip/node = SubResource("AnimationNodeBlend2_5q6cm")
 nodes/Grip/position = Vector2(0, 40)
-nodes/OpenHand/node = SubResource("AnimationNodeAnimation_djme2")
+nodes/OpenHand/node = SubResource("AnimationNodeAnimation_emwdi")
 nodes/OpenHand/position = Vector2(-600, 100)
-nodes/Trigger/node = SubResource("AnimationNodeBlend2_2oo4h")
+nodes/Trigger/node = SubResource("AnimationNodeBlend2_0neuw")
 nodes/Trigger/position = Vector2(-360, 40)
 node_connections = [&"Grip", 0, &"Trigger", &"Grip", 1, &"ClosedHand2", &"Trigger", 0, &"OpenHand", &"Trigger", 1, &"ClosedHand1", &"output", 0, &"Grip"]
 
@@ -90,10 +90,18 @@ size = Vector3(14, 10, 14)
 [node name="XROrigin3D" parent="." index="0"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5, 3)
 
+[node name="LeftHand" parent="XROrigin3D" index="1"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, -0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
+
 [node name="LeftHand" parent="XROrigin3D/LeftHand" index="0" instance=ExtResource("2_dss28")]
 
+[node name="Hand_Nails_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56577e-05, -0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
@@ -121,16 +129,27 @@ bone_idx = 9
 [node name="Poke" parent="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L/Armature/Skeleton3D/BoneAttachment3D" index="0" instance=ExtResource("3_cmo20")]
 
 [node name="AnimationTree" parent="XROrigin3D/LeftHand/LeftHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_m26jc")
+root_node = NodePath("../Hand_Nails_low_L")
+tree_root = SubResource("AnimationNodeBlendTree_nnm50")
 
 [node name="FunctionPickup" parent="XROrigin3D/LeftHand" index="1" instance=ExtResource("3_gbd4b")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="ControlPadLocationLeft" parent="XROrigin3D/LeftHand" index="2" instance=ExtResource("4_12d7t")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
+
+[node name="RightHand" parent="XROrigin3D" index="2"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, -0.707107, 0, 0.707107, 0.707107, 0.5, 1, -0.5)
+pose = &"grip"
+show_when_tracked = true
 
 [node name="RightHand" parent="XROrigin3D/RightHand" index="0" instance=ExtResource("4_xv2cc")]
 
+[node name="Hand_Nails_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
+
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56577e-05, 0.0272204, 0.945824)
+bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
 bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
 bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
 bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
@@ -158,11 +177,13 @@ bone_idx = 9
 [node name="Poke" parent="XROrigin3D/RightHand/RightHand/Hand_Nails_low_R/Armature/Skeleton3D/BoneAttachment3D" index="0" instance=ExtResource("3_cmo20")]
 
 [node name="AnimationTree" parent="XROrigin3D/RightHand/RightHand" index="1"]
-tree_root = SubResource("AnimationNodeBlendTree_g51po")
+tree_root = SubResource("AnimationNodeBlendTree_f5g0g")
 
 [node name="FunctionPickup" parent="XROrigin3D/RightHand" index="1" instance=ExtResource("3_gbd4b")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="ControlPadLocationRight" parent="XROrigin3D/RightHand" index="2" instance=ExtResource("6_b12hs")]
+transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0, 0, 0)
 
 [node name="MovementTurn" parent="XROrigin3D/RightHand" index="3" instance=ExtResource("8_t38e8")]
 
@@ -270,9 +291,6 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 1, -0.3)
 [node name="Teleport" parent="." index="4" instance=ExtResource("9_7cul8")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -6)
 title = ExtResource("10_phcsg")
-spawn_point_name = ""
-spawn_point_position = Vector3(0, 0, 0)
-spawn_point_transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [editable path="XROrigin3D/LeftHand/LeftHand"]
 [editable path="XROrigin3D/LeftHand/LeftHand/Hand_Nails_low_L"]


### PR DESCRIPTION
As more and more runtimes are using the aim pose as originally intended, e.g. the direction is no longer straight ahead but what comes naturally for UI and object interaction on a platform, we're moving to supporting grip and palm pose as well.

The demos are also being updated to use the grip pose, though I may do a few demos in a separate PR just to keep this PR easier to review.

Note that you'll find a new `hand_offset_mode` property on a number of nodes that relate to hand positioning (our hand meshes, pickup function, etc). The default setting here is "auto" and it will try and figure out what pose you're using based on what's set on the controller. This means that if you're still using the aim pose, things mostly stay the same (a lot of things will now be auto positioned on the palm which they should have been from day one). If however you switch to grip, everything should nicely adjust itself.

> [!NOTE]
> The `auto` logic assumes you are using the default action map. If you've created your own pose actions, the logic doesn't know what pose this is bound to. In this case you can select `aim`, `grip` or `palm` to tell the logic which type of pose you're expecting to be used.

> [!IMPORTANT]
> Because the grip pose has a 45 degree rotation, when you use the grip pose for your controller, all the effected children will be rotated in the opposite direction. This may look weird when setting up your scene. You will see that in all demo projects I've already updated, I've rotated the `XRController3D` nodes by 45 degrees as they would be in runtime.
