### PR TITLE
Fix incorrect viewport size update behaviour in viewport_2d_in_3d.gd

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -560,8 +560,8 @@ func _update_render() -> void:
 		$Viewport.size = viewport_size
 		$StaticBody3D.viewport_size = viewport_size
 
-		# Update our viewport texture, it will have changed
-		_dirty |= _DIRTY_ALBEDO
+		# Perform redraw to let viewport texture update correctly after changing the viewport's size
+		_dirty |= _DIRTY_REDRAW
 
 	# Handle albedo change:
 	if _dirty & _DIRTY_ALBEDO:


### PR DESCRIPTION
ViewportTexture will not update accordingly after changing the SubViewport's size in editor mode, resulting incorrect visual in editor after changing viewport_size. Perform a forced redraw will solve this issue.