### PR TITLE
Fix `return_to_snap_zone` running in editor

### DIFF
--- a/addons/godot-xr-tools/objects/return_to_snap_zone.gd
+++ b/addons/godot-xr-tools/objects/return_to_snap_zone.gd
@@ -51,6 +51,9 @@ func _ready() -> void:
 
 # Handle the return counter
 func _process(delta : float) -> void:
+	if Engine.is_editor_hint():
+		return
+
 	# Update return time and skip if still waiting
 	_return_counter += delta
 	if _return_counter < return_delay:


### PR DESCRIPTION
Simple fix. I was able to reproduce and then fix by adding an `Engine.is_editor_hint()` check in the process function.

<img width="301" height="125" alt="image" src="https://github.com/user-attachments/assets/35f7a010-0f3f-4f63-8f9e-4bdc906dcaa8" />