### PR TITLE
Remove `XRToolsSnapZone` `initial_object` stash sound

### DIFF
--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -180,6 +180,13 @@ func _initial_object_check() -> void:
 		# Show highlight when empty and enabled
 		highlight_updated.emit(self, enabled)
 
+	# Stop any audio from initial pickup
+	var audio := get_node("AudioStreamPlayer3D") if has_node("AudioStreamPlayer3D") else null
+
+	# Only stop if the user doesn't intend to auto-play
+	if audio is AudioStreamPlayer3D and !audio.autoplay:
+		audio.stop()
+
 
 # Called when a body enters the snap zone
 func _on_snap_zone_body_entered(target: Node3D) -> void:


### PR DESCRIPTION
Stopping the sound after `pick_up_object()` in `_initial_object_check()` allows the stash sound to be suppressed only when that function is used, stopping it from playing during scene loading, but allowing it to play any other time. There is an exception if the AudioStreamPlayer3D has been marked as autoplay by the user. Tested in the `pickable_demo` by making the teacup snap zone play a long and loud audio file with attenuation disabled.

IMPORTANT:
This will still play audio when testing in the `pickable_demo` because of the `XRToolsReturnToSnapZone` picking up the object after a default one-second delay in the editor (which is fixed in #748).