### PR TITLE
Fix shadowed variable names in `is_xr_class()`

### DIFF
--- a/addons/godot-xr-tools/audio/area_audio.gd
+++ b/addons/godot-xr-tools/audio/area_audio.gd
@@ -18,8 +18,8 @@ extends AudioStreamPlayer3D
 
 
 # Add support for is_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsAreaAudio"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsAreaAudio"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/audio/pickable_audio.gd
+++ b/addons/godot-xr-tools/audio/pickable_audio.gd
@@ -21,8 +21,8 @@ extends AudioStreamPlayer3D
 
 
 # Add support for is_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsPickableAudio"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsPickableAudio"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/audio/surface_audio.gd
+++ b/addons/godot-xr-tools/audio/surface_audio.gd
@@ -16,8 +16,8 @@ extends Node
 
 
 # Add support for is_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsSurfaceAudio"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsSurfaceAudio"
 
 
 # This method checks for configuration issues.

--- a/addons/godot-xr-tools/desktop-support/controler_hider.gd
+++ b/addons/godot-xr-tools/desktop-support/controler_hider.gd
@@ -26,8 +26,8 @@ func _ready() -> void:
 		_pointer_disabler = true
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsDesktopControlerHider"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsDesktopControlerHider"
 
 func _process(_delta: float) -> void:
 	if Engine.is_editor_hint() or !is_inside_tree():

--- a/addons/godot-xr-tools/desktop-support/function_desktop_pointer.gd
+++ b/addons/godot-xr-tools/desktop-support/function_desktop_pointer.gd
@@ -117,8 +117,8 @@ var _world_scale : float = 1.0
 	"XRToolsStaging"),"StartXR","Node")
 
 ## Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsDesktopFunctionPointer"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsDesktopFunctionPointer"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/desktop-support/mouse_capture.gd
+++ b/addons/godot-xr-tools/desktop-support/mouse_capture.gd
@@ -26,8 +26,8 @@ extends XRToolsMovementProvider
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsDesktopMouseCapture" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsDesktopMouseCapture" or super(xr_name)
 
 
 # Perform jump movement

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.gd
@@ -47,8 +47,8 @@ var _crouch_button_down : bool = false
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementCrouch" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementCrouch" or super(xr_name)
 
 
 # Perform jump movement

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_direct.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_direct.gd
@@ -36,8 +36,8 @@ extends XRToolsMovementProvider
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsDesktopMovementDirect" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsDesktopMovementDirect" or super(xr_name)
 
 
 # Perform jump movement

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_flight.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_flight.gd
@@ -79,8 +79,8 @@ var _flight_button : bool = false
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsDesktopMovementFlight" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsDesktopMovementFlight" or super(xr_name)
 
 
 func _ready():

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_jump.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_jump.gd
@@ -28,8 +28,8 @@ extends XRToolsMovementProvider
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsDesktopMovementJump" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsDesktopMovementJump" or super(xr_name)
 
 
 # Perform jump movement

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_sprint.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_sprint.gd
@@ -60,8 +60,8 @@ var _direct_original_max_speed : float = 0.0
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsDesktopMovementSprint" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsDesktopMovementSprint" or super(xr_name)
 
 
 func _ready():

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_turn.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_turn.gd
@@ -59,8 +59,8 @@ var _turn_step : float = 0.0
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsDesktopMovementTurn" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsDesktopMovementTurn" or super(xr_name)
 
 func _unhandled_input(event):
 	if !enabled:

--- a/addons/godot-xr-tools/effects/fade.gd
+++ b/addons/godot-xr-tools/effects/fade.gd
@@ -22,8 +22,8 @@ var _material : ShaderMaterial
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsFade"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsFade"
 
 
 # Called when the fade node is ready

--- a/addons/godot-xr-tools/effects/vignette.gd
+++ b/addons/godot-xr-tools/effects/vignette.gd
@@ -99,8 +99,8 @@ func set_auto_rotation_limit(new_auto_rotation_limit : float) -> void:
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsVignette"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsVignette"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/examples/fall_damage.gd
+++ b/addons/godot-xr-tools/examples/fall_damage.gd
@@ -49,8 +49,8 @@ var _previous_velocity : Vector3 = Vector3.ZERO
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsFallDamage"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsFallDamage"
 
 
 func _ready():

--- a/addons/godot-xr-tools/functions/function_gaze_pointer.gd
+++ b/addons/godot-xr-tools/functions/function_gaze_pointer.gd
@@ -136,8 +136,8 @@ var _world_scale : float = 1.0
 var _camera_parent : XRCamera3D
 
 ## Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsFunctionGazePointer"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsFunctionGazePointer"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -95,8 +95,8 @@ var _active_copied_collisions : Array[CopiedCollision]
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsFunctionPickup"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsFunctionPickup"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/functions/function_pointer.gd
+++ b/addons/godot-xr-tools/functions/function_pointer.gd
@@ -121,8 +121,8 @@ var _active_controller : XRController3D
 
 
 ## Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsFunctionPointer"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsFunctionPointer"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/functions/function_pose_detector.gd
+++ b/addons/godot-xr-tools/functions/function_pose_detector.gd
@@ -23,8 +23,8 @@ var _hand : XRToolsHand
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsFunctionPoseDetector"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsFunctionPoseDetector"
 
 
 # Called when we enter our tree

--- a/addons/godot-xr-tools/functions/function_teleport.gd
+++ b/addons/godot-xr-tools/functions/function_teleport.gd
@@ -108,8 +108,8 @@ var player : Node3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsFunctionTeleport"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsFunctionTeleport"
 
 
 func _enter_tree():

--- a/addons/godot-xr-tools/functions/movement_climb.gd
+++ b/addons/godot-xr-tools/functions/movement_climb.gd
@@ -82,8 +82,8 @@ var _dominant : Node3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementClimb" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementClimb" or super(xr_name)
 
 
 ## Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/functions/movement_crouch.gd
+++ b/addons/godot-xr-tools/functions/movement_crouch.gd
@@ -44,8 +44,8 @@ var _crouch_button_down : bool = false
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementCrouch" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementCrouch" or super(xr_name)
 
 
 # Perform jump movement

--- a/addons/godot-xr-tools/functions/movement_direct.gd
+++ b/addons/godot-xr-tools/functions/movement_direct.gd
@@ -30,8 +30,8 @@ extends XRToolsMovementProvider
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementDirect" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementDirect" or super(xr_name)
 
 
 # Perform jump movement

--- a/addons/godot-xr-tools/functions/movement_flight.gd
+++ b/addons/godot-xr-tools/functions/movement_flight.gd
@@ -104,8 +104,8 @@ var _controller : XRController3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementFlight" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementFlight" or super(xr_name)
 
 
 func _ready():

--- a/addons/godot-xr-tools/functions/movement_footstep.gd
+++ b/addons/godot-xr-tools/functions/movement_footstep.gd
@@ -55,8 +55,8 @@ var _ground_node_audio_type : XRToolsSurfaceAudioType
 
 
 # Add support for is_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementFootstep" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementFootstep" or super(xr_name)
 
 
 func _ready():

--- a/addons/godot-xr-tools/functions/movement_glide.gd
+++ b/addons/godot-xr-tools/functions/movement_glide.gd
@@ -91,8 +91,8 @@ var _has_controller_positions : bool = false
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementGlide" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementGlide" or super(xr_name)
 
 
 func physics_movement(delta: float, player_body: XRToolsPlayerBody, disabled: bool):

--- a/addons/godot-xr-tools/functions/movement_grapple.gd
+++ b/addons/godot-xr-tools/functions/movement_grapple.gd
@@ -103,8 +103,8 @@ var _controller_tracker_and_pose : String = ""
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementGrapple" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementGrapple" or super(xr_name)
 
 
 # Function run when node is added to scene

--- a/addons/godot-xr-tools/functions/movement_jog.gd
+++ b/addons/godot-xr-tools/functions/movement_jog.gd
@@ -59,8 +59,8 @@ var _speed_mode := SpeedMode.STOPPED
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementJog" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementJog" or super(xr_name)
 
 
 # Perform jump movement

--- a/addons/godot-xr-tools/functions/movement_jump.gd
+++ b/addons/godot-xr-tools/functions/movement_jump.gd
@@ -25,8 +25,8 @@ extends XRToolsMovementProvider
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementJump" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementJump" or super(xr_name)
 
 
 # Perform jump movement

--- a/addons/godot-xr-tools/functions/movement_physical_jump.gd
+++ b/addons/godot-xr-tools/functions/movement_physical_jump.gd
@@ -92,8 +92,8 @@ class SlidingAverage:
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementPhysicalJump" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementPhysicalJump" or super(xr_name)
 
 
 # Perform jump detection

--- a/addons/godot-xr-tools/functions/movement_provider.gd
+++ b/addons/godot-xr-tools/functions/movement_provider.gd
@@ -45,8 +45,8 @@ func _create_player_body_node():
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementProvider"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementProvider"
 
 
 # Function run when node is added to scene

--- a/addons/godot-xr-tools/functions/movement_sprint.gd
+++ b/addons/godot-xr-tools/functions/movement_sprint.gd
@@ -72,8 +72,8 @@ var _right_controller_original_max_speed : float = 0.0
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementSprint" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementSprint" or super(xr_name)
 
 
 func _ready():

--- a/addons/godot-xr-tools/functions/movement_turn.gd
+++ b/addons/godot-xr-tools/functions/movement_turn.gd
@@ -44,8 +44,8 @@ var _turn_step : float = 0.0
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementTurn" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementTurn" or super(xr_name)
 
 
 # Perform jump movement

--- a/addons/godot-xr-tools/functions/movement_wind.gd
+++ b/addons/godot-xr-tools/functions/movement_wind.gd
@@ -41,8 +41,8 @@ var _active_wind_area : XRToolsWindArea
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementWind" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementWind" or super(xr_name)
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/functions/movement_world_grab.gd
+++ b/addons/godot-xr-tools/functions/movement_world_grab.gd
@@ -52,8 +52,8 @@ var _right_handle : Node3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMovementGrabWorld" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMovementGrabWorld" or super(xr_name)
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/hands/collision_hand.gd
+++ b/addons/godot-xr-tools/hands/collision_hand.gd
@@ -117,8 +117,8 @@ func set_held_weight(new_weight):
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsCollisionHand"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsCollisionHand"
 
 
 # Return warnings related to this node

--- a/addons/godot-xr-tools/hands/hand.gd
+++ b/addons/godot-xr-tools/hands/hand.gd
@@ -102,8 +102,8 @@ class TargetOverride:
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsHand"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsHand"
 
 
 ## Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/hands/hand_aim_offset.gd
+++ b/addons/godot-xr-tools/hands/hand_aim_offset.gd
@@ -27,8 +27,8 @@ var _apply_to : Node3D
 var _base_transform : Transform3D = Transform3D()
 
 ## Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsHandAimOffset"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsHandAimOffset"
 
 
 ## Set the node we apply our transform to

--- a/addons/godot-xr-tools/hands/hand_palm_offset.gd
+++ b/addons/godot-xr-tools/hands/hand_palm_offset.gd
@@ -27,8 +27,8 @@ var _apply_to : Node3D
 var _base_transform : Transform3D = Transform3D()
 
 ## Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsHandAimOffset"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsHandAimOffset"
 
 
 ## Set the node we apply our transform to

--- a/addons/godot-xr-tools/hands/hand_physics_bone.gd
+++ b/addons/godot-xr-tools/hands/hand_physics_bone.gd
@@ -48,8 +48,8 @@ var _skeletal_bone : Node3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsHandPhysicsBone"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsHandPhysicsBone"
 
 
 # Called when the node enters the scene tree. This constructs the physics-bone

--- a/addons/godot-xr-tools/hands/physics_hand.gd
+++ b/addons/godot-xr-tools/hands/physics_hand.gd
@@ -36,5 +36,5 @@ const DEFAULT_LAYER := 0b0000_0000_0000_0010_0000_0000_0000_0000
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsPhysicsHand" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsPhysicsHand" or super(xr_name)

--- a/addons/godot-xr-tools/interactables/interactable_area_button.gd
+++ b/addons/godot-xr-tools/interactables/interactable_area_button.gd
@@ -46,8 +46,8 @@ var _tween: Tween
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsInteractableAreaButton"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsInteractableAreaButton"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/interactables/interactable_handle.gd
+++ b/addons/godot-xr-tools/interactables/interactable_handle.gd
@@ -28,8 +28,8 @@ extends XRToolsPickable
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsInteractableHandle" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsInteractableHandle" or super(xr_name)
 
 
 # Called when this handle is added to the scene

--- a/addons/godot-xr-tools/interactables/interactable_handle_driven.gd
+++ b/addons/godot-xr-tools/interactables/interactable_handle_driven.gd
@@ -25,8 +25,8 @@ var grabbed_handles := Array()
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsInteractableHandleDriven"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsInteractableHandleDriven"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/interactables/interactable_hinge.gd
+++ b/addons/godot-xr-tools/interactables/interactable_hinge.gd
@@ -47,8 +47,8 @@ signal hinge_moved(angle)
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsInteractableHinge" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsInteractableHinge" or super(xr_name)
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/interactables/interactable_joystick.gd
+++ b/addons/godot-xr-tools/interactables/interactable_joystick.gd
@@ -74,8 +74,8 @@ const VECTOR_YZ := Vector3(0.0, 1.0, 1.0)
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsInteractableJoystick" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsInteractableJoystick" or super(xr_name)
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/interactables/interactable_slider.gd
+++ b/addons/godot-xr-tools/interactables/interactable_slider.gd
@@ -39,8 +39,8 @@ signal slider_moved(position)
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsInteractableSlider" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsInteractableSlider" or super(xr_name)
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/misc/hold_button.gd
+++ b/addons/godot-xr-tools/misc/hold_button.gd
@@ -28,8 +28,8 @@ var xr_start_node : XRToolsStartXR
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsHoldButton"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsHoldButton"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/misc/move_to.gd
+++ b/addons/godot-xr-tools/misc/move_to.gd
@@ -32,8 +32,8 @@ var _time: float = 0.0
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsMoveTo"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsMoveTo"
 
 
 ## Initialize the XRToolsMoveTo

--- a/addons/godot-xr-tools/objects/climbable.gd
+++ b/addons/godot-xr-tools/objects/climbable.gd
@@ -27,8 +27,8 @@ var _grabs : Dictionary = {}
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsClimbable"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsClimbable"
 
 
 # Called when the node becomes "ready"

--- a/addons/godot-xr-tools/objects/force_body/force_body.gd
+++ b/addons/godot-xr-tools/objects/force_body/force_body.gd
@@ -35,8 +35,8 @@ class ForceBodyCollision:
 
 
 ## Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsForceBody"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsForceBody"
 
 
 ## This function moves and slides along the [param move] vector. It returns

--- a/addons/godot-xr-tools/objects/hand_pose_area.gd
+++ b/addons/godot-xr-tools/objects/hand_pose_area.gd
@@ -23,8 +23,8 @@ extends Area3D
 @export var grabpoints : Array[XRToolsGrabPointHand]
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsHandPoseArea"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsHandPoseArea"
 
 # Disables grabpoints
 func disable_grab_points():

--- a/addons/godot-xr-tools/objects/highlight/highlight_material.gd
+++ b/addons/godot-xr-tools/objects/highlight/highlight_material.gd
@@ -15,8 +15,8 @@ var _highlight_mesh_instance: MeshInstance3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsHighlightMaterial"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsHighlightMaterial"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/objects/highlight/highlight_ring.gd
+++ b/addons/godot-xr-tools/objects/highlight/highlight_ring.gd
@@ -4,8 +4,8 @@ extends MeshInstance3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsHighlightRing"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsHighlightRing"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/objects/highlight/highlight_visible.gd
+++ b/addons/godot-xr-tools/objects/highlight/highlight_visible.gd
@@ -4,8 +4,8 @@ extends Node3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsHighlightVisible"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsHighlightVisible"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/objects/interactable_area.gd
+++ b/addons/godot-xr-tools/objects/interactable_area.gd
@@ -8,5 +8,5 @@ signal pointer_event(event)
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsInteractableArea"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsInteractableArea"

--- a/addons/godot-xr-tools/objects/keyboard/virtual_keyboard_2d.gd
+++ b/addons/godot-xr-tools/objects/keyboard/virtual_keyboard_2d.gd
@@ -25,8 +25,8 @@ var _mode: int = KeyboardMode.LOWER_CASE
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsVirtualKeyboard2D"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsVirtualKeyboard2D"
 
 
 # Handle key pressed from VirtualKey

--- a/addons/godot-xr-tools/objects/pickable.gd
+++ b/addons/godot-xr-tools/objects/pickable.gd
@@ -117,8 +117,8 @@ var _highlighted : bool = false
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsPickable"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsPickable"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/objects/return_to_snap_zone.gd
+++ b/addons/godot-xr-tools/objects/return_to_snap_zone.gd
@@ -31,8 +31,8 @@ var _held := false
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsReturnToSnapZone"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsReturnToSnapZone"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/objects/snap_zone.gd
+++ b/addons/godot-xr-tools/objects/snap_zone.gd
@@ -62,8 +62,8 @@ var _object_in_grab_area = Array()
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsSnapZone"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsSnapZone"
 
 
 func _ready():

--- a/addons/godot-xr-tools/objects/teleport_area.gd
+++ b/addons/godot-xr-tools/objects/teleport_area.gd
@@ -8,8 +8,8 @@ extends Area3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsTeleportArea"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsTeleportArea"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -123,8 +123,8 @@ var _dirty := _DIRTY_ALL
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(p_name : String) -> bool:
-	return p_name == "XRToolsViewport2DIn3D"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsViewport2DIn3D"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/objects/wind_area.gd
+++ b/addons/godot-xr-tools/objects/wind_area.gd
@@ -10,5 +10,5 @@ extends Area3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsWindArea"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsWindArea"

--- a/addons/godot-xr-tools/objects/world_grab_area.gd
+++ b/addons/godot-xr-tools/objects/world_grab_area.gd
@@ -20,8 +20,8 @@ var grab_locations := {}
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsWorldGrabArea"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsWorldGrabArea"
 
 
 # Called by XRToolsFunctionPickup

--- a/addons/godot-xr-tools/overrides/ground_physics.gd
+++ b/addons/godot-xr-tools/overrides/ground_physics.gd
@@ -18,8 +18,8 @@ extends Node
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsGroundPhysics"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsGroundPhysics"
 
 
 # This method verifies the ground physics has a valid configuration.

--- a/addons/godot-xr-tools/player/fade/fade_collision.gd
+++ b/addons/godot-xr-tools/player/fade/fade_collision.gd
@@ -27,8 +27,8 @@ var _space : PhysicsDirectSpaceState3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsFadeCollision"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsFadeCollision"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/player/player_body.gd
+++ b/addons/godot-xr-tools/player/player_body.gd
@@ -192,8 +192,8 @@ func sort_by_order(a, b) -> bool:
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsPlayerBody"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsPlayerBody"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/player/poke/poke.gd
+++ b/addons/godot-xr-tools/player/poke/poke.gd
@@ -146,8 +146,8 @@ func _update_color() -> void:
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsPoke"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsPoke"
 
 
 # Called when the node enters the scene tree for the first time.

--- a/addons/godot-xr-tools/player/poke/poke_body.gd
+++ b/addons/godot-xr-tools/player/poke/poke_body.gd
@@ -21,8 +21,8 @@ var _contact : Node3D = null
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsPokeBody" or super(name)
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsPokeBody" or super(xr_name)
 
 
 func _validate_property(property):

--- a/addons/godot-xr-tools/rumble/rumble_manager.gd
+++ b/addons/godot-xr-tools/rumble/rumble_manager.gd
@@ -23,8 +23,8 @@ var _queues: Dictionary = {}
 
 
 ## Add support for is_xr_class
-func is_xr_class(p_name: String) -> bool:
-	return p_name == "XRToolsRumbleManager"
+func is_xr_class(xr_name: String) -> bool:
+	return xr_name == "XRToolsRumbleManager"
 
 
 ## Get the default Haptics Scale value

--- a/addons/godot-xr-tools/staging/scene_base.gd
+++ b/addons/godot-xr-tools/staging/scene_base.gd
@@ -50,8 +50,8 @@ func _ready() -> void:
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsSceneBase"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsSceneBase"
 
 
 ## This method center the player on the [param p_transform] transform.

--- a/addons/godot-xr-tools/staging/staging.gd
+++ b/addons/godot-xr-tools/staging/staging.gd
@@ -124,8 +124,8 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(name : String) -> bool:
-	return name == "XRToolsStaging"
+func is_xr_class(xr_name:  String) -> bool:
+	return xr_name == "XRToolsStaging"
 
 
 ## This function loads the [param p_scene_path] scene file.

--- a/assets/3dmodelscc0/models/sniper_rifle/firearm_trigger.gd
+++ b/assets/3dmodelscc0/models/sniper_rifle/firearm_trigger.gd
@@ -17,7 +17,7 @@ var _current_controller : XRController3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name : String) -> bool:
+func is_xr_class(xr_name:  String) -> bool:
 	return xr_name == "XRFirearmTrigger"
 
 

--- a/assets/digitaln8m4r3/scripts/firearm_bolt.gd
+++ b/assets/digitaln8m4r3/scripts/firearm_bolt.gd
@@ -14,7 +14,7 @@ var _current_controller : XRController3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name : String) -> bool:
+func is_xr_class(xr_name:  String) -> bool:
 	return xr_name == "XRFirearmBolt"
 
 

--- a/assets/digitaln8m4r3/scripts/firearm_slide.gd
+++ b/assets/digitaln8m4r3/scripts/firearm_slide.gd
@@ -36,7 +36,7 @@ signal firearm_slider_moved(position)
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name : String) -> bool:
+func is_xr_class(xr_name:  String) -> bool:
 	return xr_name == "XRFirearmSlide" or super(xr_name)
 
 

--- a/assets/meshes/control_pad/control_pad_location.gd
+++ b/assets/meshes/control_pad/control_pad_location.gd
@@ -8,7 +8,7 @@ var _transform : Transform3D
 
 
 # Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name : String) -> bool:
+func is_xr_class(xr_name:  String) -> bool:
 	return xr_name == "ControlPadLocation"
 
 


### PR DESCRIPTION
Will conflict with PR *#738. Renames the param `name` to `xr_name`. I was careful to also do this in the `super(name)` calls. Searching all files in the project, there are no missing `super(name)` (it was not called anywhere else), and no remaining `is_xr_class(name`.