### PR TITLE
Make sure we get our parent XRController3D node on reparent

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -10,6 +10,7 @@
 - Gracefully handle freed objects with collision exceptions
 - Added support for using grip or palm pose instead of aim pose
 - Various bits of code cleanup
+- Improved player body collisions so players can move over tables
 
 # 4.4.0
 - Minimum Godot version changed to 4.2

--- a/addons/godot-xr-tools/functions/function_pointer.gd
+++ b/addons/godot-xr-tools/functions/function_pointer.gd
@@ -180,25 +180,27 @@ func _enter_tree():
 func _exit_tree():
 	_active_controller = null
 
-	if _controller:
+	if _controller and not Engine.is_editor_hint():
 		_controller.button_pressed.disconnect(_on_button_pressed.bind(_controller))
 		_controller.button_released.disconnect(_on_button_released.bind(_controller))
 
 		# This will be unset in our superclass method
 
 	if _controller_left_node:
-		_controller_left_node.button_pressed.disconnect(
-				_on_button_pressed.bind(_controller_left_node))
-		_controller_left_node.button_released.disconnect(
-				_on_button_released.bind(_controller_left_node))
+		if not Engine.is_editor_hint():
+			_controller_left_node.button_pressed.disconnect(
+					_on_button_pressed.bind(_controller_left_node))
+			_controller_left_node.button_released.disconnect(
+					_on_button_released.bind(_controller_left_node))
 
 		_controller_left_node = null
 
 	if _controller_right_node:
-		_controller_right_node.button_pressed.disconnect(
-				_on_button_pressed.bind(_controller_right_node))
-		_controller_right_node.button_released.disconnect(
-				_on_button_released.bind(_controller_right_node))
+		if not Engine.is_editor_hint():
+			_controller_right_node.button_pressed.disconnect(
+					_on_button_pressed.bind(_controller_right_node))
+			_controller_right_node.button_released.disconnect(
+					_on_button_released.bind(_controller_right_node))
 
 		_controller_right_node = null
 

--- a/addons/godot-xr-tools/functions/movement_crouch.gd
+++ b/addons/godot-xr-tools/functions/movement_crouch.gd
@@ -40,7 +40,7 @@ var _crouch_button_down : bool = false
 
 
 # Controller node
-@onready var _controller := XRHelpers.get_xr_controller(self)
+var _controller : XRController3D
 
 
 # Add support for is_xr_class on XRTools classes
@@ -48,10 +48,20 @@ func is_xr_class(xr_name:  String) -> bool:
 	return xr_name == "XRToolsMovementCrouch" or super(xr_name)
 
 
+# Called when our node is added to our scene tree
+func _enter_tree():
+	_controller = XRHelpers.get_xr_controller(self)
+
+
+# Called when our node is removed from our scene tree
+func _exit_tree():
+	_controller = null
+
+
 # Perform jump movement
 func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
 	# Skip if the controller isn't active
-	if !_controller.get_is_active():
+	if not _controller or not _controller.get_is_active():
 		return
 
 	# Detect crouch button down and pressed states
@@ -85,7 +95,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := super()
 
 	# Check the controller node
-	if !XRHelpers.get_xr_controller(self):
+	if not XRHelpers.get_xr_controller(self):
 		warnings.append("This node must be within a branch of an XRController3D node")
 
 	# Return warnings

--- a/addons/godot-xr-tools/functions/movement_direct.gd
+++ b/addons/godot-xr-tools/functions/movement_direct.gd
@@ -26,7 +26,7 @@ extends XRToolsMovementProvider
 
 
 # Controller node
-@onready var _controller := XRHelpers.get_xr_controller(self)
+var _controller : XRController3D
 
 
 # Add support for is_xr_class on XRTools classes
@@ -34,10 +34,20 @@ func is_xr_class(xr_name:  String) -> bool:
 	return xr_name == "XRToolsMovementDirect" or super(xr_name)
 
 
+# Called when our node is added to our scene tree
+func _enter_tree():
+	_controller = XRHelpers.get_xr_controller(self)
+
+
+# Called when our node is removed from our scene tree
+func _exit_tree():
+	_controller = null
+
+
 # Perform jump movement
 func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
 	# Skip if the controller isn't active
-	if !_controller.get_is_active():
+	if not _controller or not _controller.get_is_active():
 		return
 
 	## get input action with deadzone correction applied
@@ -58,7 +68,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := super()
 
 	# Check the controller node
-	if !XRHelpers.get_xr_controller(self):
+	if not XRHelpers.get_xr_controller(self):
 		warnings.append("This node must be within a branch of an XRController3D node")
 
 	# Return warnings

--- a/addons/godot-xr-tools/functions/movement_jump.gd
+++ b/addons/godot-xr-tools/functions/movement_jump.gd
@@ -21,7 +21,7 @@ extends XRToolsMovementProvider
 
 
 # Node references
-@onready var _controller := XRHelpers.get_xr_controller(self)
+var _controller : XRController3D
 
 
 # Add support for is_xr_class on XRTools classes
@@ -29,10 +29,20 @@ func is_xr_class(xr_name:  String) -> bool:
 	return xr_name == "XRToolsMovementJump" or super(xr_name)
 
 
+# Called when our node is added to our scene tree
+func _enter_tree():
+	_controller = XRHelpers.get_xr_controller(self)
+
+
+# Called when our node is removed from our scene tree
+func _exit_tree():
+	_controller = null
+
+
 # Perform jump movement
 func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
 	# Skip if the jump controller isn't active
-	if !_controller.get_is_active():
+	if not _controller or not _controller.get_is_active():
 		return
 
 	# Request jump if the button is pressed
@@ -45,7 +55,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := super()
 
 	# Check the controller node
-	if !XRHelpers.get_xr_controller(self):
+	if not XRHelpers.get_xr_controller(self):
 		warnings.append("This node must be within a branch of an XRController3D node")
 
 	# Return warnings

--- a/addons/godot-xr-tools/functions/movement_turn.gd
+++ b/addons/godot-xr-tools/functions/movement_turn.gd
@@ -40,7 +40,7 @@ var _turn_step : float = 0.0
 
 
 # Controller node
-@onready var _controller := XRHelpers.get_xr_controller(self)
+var _controller : XRController3D
 
 
 # Add support for is_xr_class on XRTools classes
@@ -48,10 +48,20 @@ func is_xr_class(xr_name:  String) -> bool:
 	return xr_name == "XRToolsMovementTurn" or super(xr_name)
 
 
+# Called when our node is added to our scene tree
+func _enter_tree():
+	_controller = XRHelpers.get_xr_controller(self)
+
+
+# Called when our node is removed from our scene tree
+func _exit_tree():
+	_controller = null
+
+
 # Perform jump movement
 func physics_movement(delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
 	# Skip if the controller isn't active
-	if !_controller.get_is_active():
+	if not _controller or not _controller.get_is_active():
 		return
 
 	var deadzone = 0.1
@@ -92,7 +102,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := super()
 
 	# Check the controller node
-	if !XRHelpers.get_xr_controller(self):
+	if not XRHelpers.get_xr_controller(self):
 		warnings.append("Unable to find XRController3D node")
 
 	# Return warnings

--- a/addons/godot-xr-tools/hands/collision_hand.gd
+++ b/addons/godot-xr-tools/hands/collision_hand.gd
@@ -268,7 +268,6 @@ func _move_to_target(delta):
 
 	# Handle too far from target
 	if global_position.distance_to(_target.global_position) > TELEPORT_DISTANCE:
-		print("max distance reached")
 		max_distance_reached.emit()
 
 		global_transform = _target.global_transform

--- a/addons/godot-xr-tools/objects/grab_points/grab_point_hand.gd
+++ b/addons/godot-xr-tools/objects/grab_points/grab_point_hand.gd
@@ -152,14 +152,7 @@ func _update_editor_preview() -> void:
 
 	# Construct the model
 	_editor_preview_hand = hand_scene.instantiate()
-
-	# Keep this backwards compatible,
-	# position the hand according to the original aim logic
-	var custom_offset := Transform3D()
-	# Note, base transform adds another 0.01 to x and 0.05 to z, it doesn't know which hand we're on.
-	custom_offset.origin = Vector3(-0.04 if hand == Hand.LEFT else 0.02, -0.05, 0.10)
-	_editor_preview_hand.hand_offset_mode = 4 # Custom
-	_editor_preview_hand.hand_custom_offset = custom_offset
+	_editor_preview_hand.hand_offset_mode = 4 # Disabled
 
 	# Set the pose
 	if hand_pose:
@@ -173,6 +166,14 @@ func _update_editor_preview() -> void:
 
 	# Add the editor-preview hand as a child
 	add_child(_editor_preview_hand, false, Node.INTERNAL_MODE_BACK)
+
+	# Keep this backwards compatible,
+	# position the hand according to the original aim logic
+	var hand_node : Node3D = _editor_preview_hand.get_child(0)
+	if hand_node:
+		var custom_offset := Transform3D()
+		custom_offset.origin = Vector3(-0.03 if hand == Hand.LEFT else 0.03, -0.05, 0.15)
+		hand_node.transform = custom_offset
 
 
 # Is the grabber for the correct hand

--- a/scenes/main_menu/main_menu_level.tscn
+++ b/scenes/main_menu/main_menu_level.tscn
@@ -128,27 +128,6 @@ show_when_tracked = true
 [node name="Hand_low_L" parent="XROrigin3D/LeftHand/LeftHand" index="0"]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, -0.01, 0.0353553, 0.0353553)
 
-[node name="Skeleton3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_low_L/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
-bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
-bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
-bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
-bones/6/rotation = Quaternion(0.102925, -0.00993208, -0.00794417, 0.994608)
-bones/7/rotation = Quaternion(-0.012859, -0.0236108, -0.323258, 0.945929)
-bones/8/rotation = Quaternion(0.0120575, -0.00929194, -0.247472, 0.968775)
-bones/10/rotation = Quaternion(-0.0357539, -0.000400032, 0.00636764, 0.99934)
-bones/11/rotation = Quaternion(-0.00264964, -0.00114471, -0.125992, 0.992027)
-bones/12/rotation = Quaternion(0.0394225, 0.00193393, -0.228074, 0.972843)
-bones/13/rotation = Quaternion(-0.0123395, -0.00881294, -0.280669, 0.959685)
-bones/15/rotation = Quaternion(-0.0702656, 0.0101908, -0.0243307, 0.99718)
-bones/16/rotation = Quaternion(-0.0320634, -0.00223624, -0.0686366, 0.997124)
-bones/17/rotation = Quaternion(0.0253452, 0.00812462, -0.249005, 0.968136)
-bones/18/rotation = Quaternion(0.00252232, 0.00788073, -0.243204, 0.96994)
-bones/20/rotation = Quaternion(-0.0917369, 0.0203027, -0.010183, 0.995524)
-bones/21/rotation = Quaternion(-0.0625182, -0.00022572, -0.115393, 0.991351)
-bones/22/rotation = Quaternion(0.0585786, 0.0216483, -0.269905, 0.96086)
-bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
-
 [node name="BoneAttachment3D" type="BoneAttachment3D" parent="XROrigin3D/LeftHand/LeftHand/Hand_low_L/Armature/Skeleton3D" index="1"]
 transform = Transform3D(0.54083, 0.840813, -0.0231736, -0.0826267, 0.0805243, 0.993322, 0.837064, -0.535303, 0.113023, 0.039902, 0.0402828, -0.150096)
 bone_name = "Index_Tip_L"
@@ -180,27 +159,6 @@ show_when_tracked = true
 
 [node name="Hand_low_R" parent="XROrigin3D/RightHand/RightHand" index="0"]
 transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 0.01, 0.0353553, 0.0353553)
-
-[node name="Skeleton3D" parent="XROrigin3D/RightHand/RightHand/Hand_low_R/Armature" index="0"]
-bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
-bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
-bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
-bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
-bones/6/rotation = Quaternion(0.102925, 0.00993208, 0.00794419, 0.994608)
-bones/7/rotation = Quaternion(-0.012859, 0.0236108, 0.323258, 0.945929)
-bones/8/rotation = Quaternion(0.0120575, 0.00929193, 0.247472, 0.968775)
-bones/10/rotation = Quaternion(-0.0357539, 0.000400032, -0.00636763, 0.99934)
-bones/11/rotation = Quaternion(-0.00264964, 0.00114471, 0.125992, 0.992027)
-bones/12/rotation = Quaternion(0.0394225, -0.00193393, 0.228074, 0.972843)
-bones/13/rotation = Quaternion(-0.0123395, 0.00881294, 0.280669, 0.959685)
-bones/15/rotation = Quaternion(-0.0702656, -0.0101908, 0.0243307, 0.99718)
-bones/16/rotation = Quaternion(-0.0320634, 0.00223624, 0.0686366, 0.997124)
-bones/17/rotation = Quaternion(0.0253452, -0.00812462, 0.249005, 0.968136)
-bones/18/rotation = Quaternion(0.00252233, -0.00788073, 0.243204, 0.96994)
-bones/20/rotation = Quaternion(-0.0917369, -0.0203027, 0.010183, 0.995524)
-bones/21/rotation = Quaternion(-0.0625182, 0.000225721, 0.115393, 0.991351)
-bones/22/rotation = Quaternion(0.0585786, -0.0216483, 0.269905, 0.96086)
-bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 
 [node name="mesh_Hand_low_R" parent="XROrigin3D/RightHand/RightHand/Hand_low_R/Armature/Skeleton3D" index="0"]
 surface_material_override/0 = ExtResource("26_id1x7")


### PR DESCRIPTION
I already fixed this on a few other script but went through the rest.

XR Tools was designed so you can reparent child nodes of the XRController3D nodes to swap left handed/right handed behaviour, however many script initialised on ready and don't react to reparenting.

This PR addresses this.

Do note that the features that work on both hands (like climbing) do not trigger any logic here but I think in that scenario we'll be ok. Needs testing.

Fixes #743

Breaking my own rules here because I was dumb enough not to change branches. Bonus enhancement, you can now bend over tables and configure the playerbody to perform a fade to black when you stick your head through a wall :)

<img width="559" height="632" alt="image" src="https://github.com/user-attachments/assets/da435a2b-1e27-4500-b1f3-ee115e258664" />
