### PR TITLE
Function_Pikcup _set_ranged_collision_mask typo

### DIFF
--- a/addons/godot-xr-tools/functions/function_pickup.gd
+++ b/addons/godot-xr-tools/functions/function_pickup.gd
@@ -271,8 +271,8 @@ func _set_ranged_angle(new_value: float) -> void:
 # Called when the ranged-grab collision mask has been modified
 func _set_ranged_collision_mask(new_value: int) -> void:
 	ranged_collision_mask = new_value
-	if is_inside_tree() and _ranged_collision:
-		_ranged_collision.collision_mask = new_value
+	if is_inside_tree() and _ranged_area:
+		_ranged_area.collision_mask = new_value
 
 
 # Update the colliders geometry


### PR DESCRIPTION
Changed _ranged_collision to _ranged_area since I was getting error because _range_collision doesn't have property .collision_mask. _ranged_collision is defined earlier in the file as a 'CollisionShape3D' but on godots [documentation](https://docs.godotengine.org/en/stable/classes/class_collisionshape3d.html) collision shape3d don't have .collsion_mask as a property. There is a similar function a few lines above that deals with the non-ranged grab version that uses the correct Area3D reference so I just replaced it with that (the function name is _set_grab_collision_mask).