### PR TITLE
Better format Area Audio Type

### DIFF
--- a/addons/godot-xr-tools/audio/area_audio_type.gd
+++ b/addons/godot-xr-tools/audio/area_audio_type.gd
@@ -9,12 +9,11 @@ extends Resource
 ## This resource defines the audio stream to play when
 ## a objects enters it
 
-
 ## Surface name
-@export var name : String = ""
+@export var name: String = ""
 
 ## Optional audio stream to play when the player lands on this surface
-@export var touch_sound : AudioStream
+@export var touch_sound: AudioStream
 
 
 # This method checks for configuration issues.


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons

## Disclaimer
No generative AI was used to enhance or create the code given here.