### PR TITLE
Better format Pickable Audio Type

### DIFF
--- a/addons/godot-xr-tools/audio/pickable_audio_type.gd
+++ b/addons/godot-xr-tools/audio/pickable_audio_type.gd
@@ -3,27 +3,25 @@
 class_name XRToolsPickableAudioType
 extends Resource
 
-
 ## XRTools Pickable Audio Type Resource
 ##
 ## This resource defines the audio streams to play when
 ## the pickable is being picked up/ dropped/ hit something while being held
 
-
 ## Surface name
-@export var name : String = ""
+@export var name: String = ""
 
 ## Optional audio stream to play when the player picks up the pickable
-@export var grab_sound : AudioStream
+@export var grab_sound: AudioStream
 
 ## Optional audio stream to play when the player drops the pickable
-@export var drop_sound : AudioStream
+@export var drop_sound: AudioStream
 
 ## Optional audio stream to play when the item is beign held by the player
-@export var hit_sound : AudioStream
+@export var hit_sound: AudioStream
 
 
-# This method checks for configuration issues.
+# Checks for configuration issues.
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := PackedStringArray()
 


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove space between variable names and colons

## Disclaimer
No generative AI was used to enhance or create the code given here.