### PR TITLE
Better format Surface Audio Type

### DIFF
--- a/addons/godot-xr-tools/audio/surface_audio_type.gd
+++ b/addons/godot-xr-tools/audio/surface_audio_type.gd
@@ -3,7 +3,6 @@
 class_name XRToolsSurfaceAudioType
 extends Resource
 
-
 ## XRTools Surface Type Resource
 ##
 ## This resource defines a type of surface, and the audio streams to play when
@@ -11,25 +10,25 @@ extends Resource
 
 
 ## Surface name
-@export var name : String = ""
+@export var name: String = ""
 
 ## Optional audio stream to play when the player jumps on this surface
-@export var jump_sound : AudioStream
+@export var jump_sound: AudioStream
 
 ## Optional audio stream to play when the player lands on this surface
-@export var hit_sound : AudioStream
+@export var hit_sound: AudioStream
 
 ## Audio streams to play when the player walks on this surface
-@export var walk_sounds :Array[AudioStream] = []
+@export var walk_sounds: Array[AudioStream] = []
 
 ## Walking sound minimum pitch (to randomize steps)
-@export_range(0.5, 1.0) var walk_pitch_minimum : float = 0.8
+@export_range(0.5, 1.0) var walk_pitch_minimum: float = 0.8
 
 ## Walking sound maximum pitch (to randomize steps)
-@export_range(1.0, 2.0) var walk_pitch_maximum : float = 1.2
+@export_range(1.0, 2.0) var walk_pitch_maximum: float = 1.2
 
 
-# This method checks for configuration issues.
+# Checks for configuration issues.
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := PackedStringArray()
 


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Remove spaces between variable names and colons

## Disclaimer
No generative AI was used to enhance or create the code given here.