### PR TITLE
Better format and static type Desktop Crouch

### DIFF
--- a/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.gd
@@ -2,7 +2,6 @@
 class_name XRToolsDesktopMovementCrouch
 extends XRToolsMovementProvider
 
-
 ## XR Tools Movement Provider for Crouching
 ##
 ## This script works with the [XRToolsPlayerBody] attached to the players
@@ -10,7 +9,6 @@ extends XRToolsMovementProvider
 ##
 ## While the player presses the crounch button, the height is overridden to
 ## the specified crouch height.
-
 
 ## Enumeration of crouching modes
 enum CrouchType {
@@ -20,46 +18,55 @@ enum CrouchType {
 
 
 ## Movement provider order
-@export var order : int = 10
+@export var order: int = 10
 
 ## Crouch height
-@export var crouch_height : float = 1.0
+@export var crouch_height: float = 1.0
 
 ## Crouch button
-@export var crouch_button_action : String = "action_crouch"
+@export var crouch_button_action: String = "action_crouch"
 
 ## Type of crouching
-@export var crouch_type : CrouchType = CrouchType.HOLD_TO_CROUCH
+@export var crouch_type: CrouchType = CrouchType.HOLD_TO_CROUCH
 
 
 ## Crouching flag
-var _crouching : bool = false
+var _crouching: bool = false
 
 ## Crouch button down state
-var _crouch_button_down : bool = false
+var _crouch_button_down: bool = false
 
 
-# Controller node
-@onready var xr_start_node = XRTools.find_xr_child(
-	XRTools.find_xr_ancestor(self,
-	"*Staging",
-	"XRToolsStaging"),"StartXR","Node")
+## Controller node
+@onready var xr_start_node: XRToolsStartXR = XRTools.find_xr_child(
+		XRTools.find_xr_ancestor(
+				self,
+				"*Staging",
+				"XRToolsStaging",
+		),
+		"StartXR",
+		"Node",
+)
 
 
-# Add support for is_xr_class on XRTools classes
-func is_xr_class(xr_name:  String) -> bool:
+## Add support for is_xr_class on XRTools classes
+func is_xr_class(xr_name: String) -> bool:
 	return xr_name == "XRToolsMovementCrouch" or super(xr_name)
 
 
-# Perform jump movement
-func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: bool):
+## Perform jump movement
+func physics_movement(
+		_delta: float,
+		player_body: XRToolsPlayerBody,
+		_disabled: bool,
+) -> void:
 	# Skip if the controller isn't active
-	if !player_body.enabled or xr_start_node.is_xr_active():
+	if not player_body.enabled or xr_start_node.is_xr_active():
 		return
 
 	# Detect crouch button down and pressed states
 	var crouch_button_down := Input.is_action_pressed(crouch_button_action)
-	var crouch_button_pressed := crouch_button_down and !_crouch_button_down
+	var crouch_button_pressed := crouch_button_down and not _crouch_button_down
 	_crouch_button_down = crouch_button_down
 
 	# Calculate new crouching state
@@ -72,11 +79,12 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 		CrouchType.TOGGLE_CROUCH:
 			# Toggle when button pressed
 			if crouch_button_pressed:
-				crouching = !crouching
+				crouching = not crouching
 
 	# Update crouching state
 	if crouching != _crouching:
 		_crouching = crouching
+
 		if crouching:
 			player_body.override_player_height(self, crouch_height)
 		else:


### PR DESCRIPTION
In accordance with [style guide given here](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html):
- Add doc comments to variables and functions where possible
- Replace exclamation marks with **not** keyword
- Format multiline statements for more readability
- Add spaces before and after equal signs
- Specify return type of function **physics_movement()**

## Disclaimer
No generative AI was used to enhance or create the code given here.