### PR TITLE
Fix hardcoded string for escape action

### DIFF
--- a/addons/godot-xr-tools/desktop-support/mouse_capture.gd
+++ b/addons/godot-xr-tools/desktop-support/mouse_capture.gd
@@ -38,7 +38,7 @@ func physics_movement(_delta: float, player_body: XRToolsPlayerBody, _disabled: 
 		return
 
 
-	if Input.is_action_just_pressed("ui_cancel"):
+	if Input.is_action_just_pressed(escape_action):
 		capture=!capture
 
 	#print(Input.mouse_mode==Input.MOUSE_MODE_CAPTURED)


### PR DESCRIPTION
Simply fixes the hardcoded string and replaces it with the member variable as reported in #720.