### PR TITLE
Fix Godot 4.x API: params_cull_mode -> cull_mode

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d.gd
@@ -504,7 +504,7 @@ func _update_render() -> void:
 			_screen_material = StandardMaterial3D.new()
 
 			# Disable culling
-			_screen_material.params_cull_mode = StandardMaterial3D.CULL_DISABLED
+			_screen_material.cull_mode = StandardMaterial3D.CULL_DISABLED
 
 			# Ensure local material is configured
 			_dirty |= _DIRTY_TRANSPARENCY |	\


### PR DESCRIPTION
The `params_cull_mode` property was renamed to `cull_mode` in Godot 4.0.

This only affects the code path when creating material from scratch in `_update_render()` (not when using the bundled `.tscn` which has the material pre-created).