### PR TITLE
Fix virtual keyboard in the pointer demo

### DIFF
--- a/addons/godot-xr-tools/objects/keyboard/virtual_keyboard_2d.gd
+++ b/addons/godot-xr-tools/objects/keyboard/virtual_keyboard_2d.gd
@@ -23,6 +23,8 @@ var _alt_down := false
 # Current keyboard mode
 var _mode: int = KeyboardMode.LOWER_CASE
 
+# Viewport node to push input to
+@onready var _viewport: Viewport = get_viewport().get_parent().get_viewport()
 
 # Add support for is_xr_class on XRTools classes
 func is_xr_class(xr_name:  String) -> bool:
@@ -41,10 +43,10 @@ func on_key_pressed(scan_code_text: String, unicode: int, shift: bool):
 	input.pressed = true
 	input.keycode = scan_code
 	input.shift_pressed = shift
-
+	
 	# Dispatch the input event
-	Input.parse_input_event(input)
-
+	_viewport.push_input(input)
+	
 	# Pop any temporary shift key
 	if _shift_down:
 		_shift_down = false

--- a/addons/godot-xr-tools/objects/keyboard/virtual_keyboard_2d.gd
+++ b/addons/godot-xr-tools/objects/keyboard/virtual_keyboard_2d.gd
@@ -23,6 +23,17 @@ var _alt_down := false
 # Current keyboard mode
 var _mode: int = KeyboardMode.LOWER_CASE
 
+# Viewport node to push input to
+var _viewport: Viewport = null
+
+
+func _ready() -> void:
+	# This should be the SubViewport in the virtual keyboard's Viewport2Din3D
+	var vp: Viewport = get_viewport()
+
+	if is_instance_valid(vp.get_parent()):
+		_viewport = vp.get_parent().get_viewport()
+
 
 ## Adds support for [method is_xr_class] on XRTools classes
 func is_xr_class(xr_name: String) -> bool:
@@ -44,6 +55,11 @@ func on_key_pressed(scan_code_text: String, unicode: int, shift: bool) -> void:
 
 	# Dispatch the input event
 	Input.parse_input_event(input)
+
+	# If the viewport of the virtual keyboard's Viewport2Din3D isn't the
+	# root viewport, we should pass the input event to that viewport as well
+	if _viewport != get_tree().root and _viewport != null:
+		_viewport.push_input(input)
 
 	# Pop any temporary shift key
 	if _shift_down:


### PR DESCRIPTION
Simple change to address https://github.com/GodotVR/godot-xr-tools/issues/792 where we get the Viewport outside of the SubViewport containing the UI and push input there instead of using:

```Input.parse_input_event(input)```

This fixes the virtual keyboard in the demo, as the demo has a SubViewport when implementing the spectator view which seems to block the input event?

One thing to note is that after this change, I still can't edit the lines in the pointer demo with my desktop keyboard, but the virtual keyboard will work.

Works on Godot 4.4.1 and 4.6.2 in the demo, and on another separate Godot XR project (without spectator view).