### PR TITLE
Fix double button presses (pointer for 2D viewport) in Godot 4.7+

### DIFF
--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
@@ -147,6 +147,7 @@ func _report_touch_down(index : int, at : Vector2) -> void:
 	event.index = index
 	event.position = at
 	event.pressed = true
+	event.device = InputEvent.DEVICE_ID_EMULATION
 	_viewport.push_input(event)
 
 
@@ -156,6 +157,7 @@ func _report_touch_up(index : int, at : Vector2) -> void:
 	event.index = index
 	event.position = at
 	event.pressed = false
+	event.device = InputEvent.DEVICE_ID_EMULATION
 	_viewport.push_input(event)
 
 
@@ -166,6 +168,7 @@ func _report_touch_move(index : int, pressed : bool, from : Vector2, to : Vector
 	event.position = to
 	event.pressure = 1.0 if pressed else 0.0
 	event.relative = to - from
+	event.device = InputEvent.DEVICE_ID_EMULATION
 	_viewport.push_input(event)
 
 

--- a/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
+++ b/addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd
@@ -195,6 +195,7 @@ func _report_touch_down(index: int, at: Vector2) -> void:
 	event.index = index
 	event.position = at
 	event.pressed = true
+    event.device = InputEvent.DEVICE_ID_EMULATION
 	_viewport.push_input(event)
 
 
@@ -210,6 +211,7 @@ func _report_touch_move(
 	event.position = to
 	event.pressure = 1.0 if pressed else 0.0
 	event.relative = to - from
+    event.device = InputEvent.DEVICE_ID_EMULATION
 	_viewport.push_input(event)
 
 
@@ -219,4 +221,5 @@ func _report_touch_up(index: int, at: Vector2) -> void:
 	event.index = index
 	event.position = at
 	event.pressed = false
+    event.device = InputEvent.DEVICE_ID_EMULATION
 	_viewport.push_input(event)


### PR DESCRIPTION
Godot version 4.7-dev5 added multitouch support to Buttons ( https://github.com/godotengine/godot/pull/110893 ).

This causes buttons displayed in 2D Viewport in 3D to misbehave. This is because `addons/godot-xr-tools/objects/viewport_2d_in_3d_body.gd` emits both a touch event and a mouse event. For buttons this was no problem before Godot 4.7-dev5, as touch events were not handled by the button.

Now however, a button press is triggered twice, once for the touch event emitted, once for the mouse event emitted. If the button is for example a toggle button, its state will now not change.

To prevent double emissions when mouse/touch emulation are enabled, the new commit guards against `InputEvent::DEVICE_ID_EMULATION`.

This PR adds a minimal change setting the input device ID of the touch events to `InputEvent::DEVICE_ID_EMULATION`. This ensures the duplicate event is ignored where appropriate. This change is also backwards compatible to at least Godot 4.3 (which is the minimum version defined for this addon (versions >=4.5.0))

`InputEvent::DEVICE_ID_EMULATION` as an enum is only defined starting Godot 4.3, in theory one could also write the direct value `-1`, which would then support even older Godot versions.