### PR TITLE
Fix dependency on staging and StartXR

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,6 @@
+# 4.6.0
+- Fix dependency on staging system
+
 # 4.5.0
 - Minimum Godot version changed to 4.4
 - Added UIDs for all classes

--- a/addons/godot-xr-tools/desktop-support/controller_hider.gd
+++ b/addons/godot-xr-tools/desktop-support/controller_hider.gd
@@ -15,7 +15,7 @@ var _last_xr_active: bool = true
 @onready var xr_start_node: Node = XRTools.find_xr_child(
 		XRTools.find_xr_ancestor(
 				self,
-				"*Staging",
+				"*",
 				"XRToolsStaging"
 		),
 		"StartXR",

--- a/addons/godot-xr-tools/desktop-support/function_desktop_pointer.gd
+++ b/addons/godot-xr-tools/desktop-support/function_desktop_pointer.gd
@@ -112,7 +112,7 @@ var _world_scale: float = 1.0
 @onready var xr_start_node: Node = XRTools.find_xr_child(
 		XRTools.find_xr_ancestor(
 				self,
-				"*Staging",
+				"*",
 				"XRToolsStaging",
 		),
 		"StartXR",

--- a/addons/godot-xr-tools/desktop-support/mouse_capture.gd
+++ b/addons/godot-xr-tools/desktop-support/mouse_capture.gd
@@ -18,15 +18,7 @@ extends XRToolsMovementProvider
 
 
 ## XRStart node
-@onready var xr_start_node: XRToolsStartXR = XRTools.find_xr_child(
-		XRTools.find_xr_ancestor(
-				self,
-				"*Staging",
-				"XRToolsStaging",
-		),
-		"StartXR",
-		"Node",
-)
+@onready var xr_start_node: XRToolsStartXR = XRToolsStartXR.get_start_xr_node()
 
 
 ## Add support for is_xr_class on XRTools classes

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.gd
@@ -38,15 +38,7 @@ var _crouch_button_down: bool = false
 
 
 ## Controller node
-@onready var xr_start_node: XRToolsStartXR = XRTools.find_xr_child(
-		XRTools.find_xr_ancestor(
-				self,
-				"*Staging",
-				"XRToolsStaging",
-		),
-		"StartXR",
-		"Node",
-)
+@onready var xr_start_node: XRToolsStartXR = XRToolsStartXR.get_start_xr_node()
 
 
 ## Add support for is_xr_class on XRTools classes

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_direct.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_direct.gd
@@ -33,15 +33,7 @@ extends XRToolsMovementProvider
 
 
 ## XRStart node
-@onready var xr_start_node: XRToolsStartXR = XRTools.find_xr_child(
-		XRTools.find_xr_ancestor(
-				self,
-				"*Staging",
-				"XRToolsStaging",
-		),
-		"StartXR",
-		"Node",
-)
+@onready var xr_start_node: XRToolsStartXR = XRToolsStartXR.get_start_xr_node()
 
 
 ## Find the right [XRToolsDesktopMovementDirect] node.

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_flight.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_flight.gd
@@ -79,7 +79,7 @@ var _flight_button: bool = false
 @onready var xr_start_node: Node = XRTools.find_xr_child(
 		XRTools.find_xr_ancestor(
 				self,
-				"*Staging",
+				"*",
 				"XRToolsStaging",
 		),
 		"StartXR",

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_jump.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_jump.gd
@@ -20,15 +20,7 @@ extends XRToolsMovementProvider
 
 
 ## XR start node
-@onready var xr_start_node: XRToolsStartXR = XRTools.find_xr_child(
-		XRTools.find_xr_ancestor(
-				self,
-				"*Staging",
-				"XRToolsStaging",
-		),
-		"StartXR",
-		"Node",
-)
+@onready var xr_start_node: XRToolsStartXR = XRToolsStartXR.get_start_xr_node()
 
 
 ## Add support for is_xr_class on XRTools classes

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_sprint.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_sprint.gd
@@ -47,15 +47,7 @@ var _direct_original_max_speed: float = 0.0
 
 
 ## XRStart node
-@onready var xr_start_node: XRToolsStartXR = XRTools.find_xr_child(
-		XRTools.find_xr_ancestor(
-				self,
-				"*Staging",
-				"XRToolsStaging",
-		),
-		"StartXR",
-		"Node",
-)
+@onready var xr_start_node: XRToolsStartXR = XRToolsStartXR.get_start_xr_node()
 
 # Direct movement node, if any
 @onready var _desktop_direct_move := XRToolsDesktopMovementDirect.find(self)

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_turn.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_turn.gd
@@ -61,7 +61,7 @@ var _turn_step: float = 0.0
 @onready var xr_start_node: XRToolsStartXR = XRTools.find_xr_child(
 		XRTools.find_xr_ancestor(
 				self,
-				"*Staging",
+				"*",
 				"XRToolsStaging",
 		),
 		"StartXR",

--- a/addons/godot-xr-tools/misc/hold_button.gd
+++ b/addons/godot-xr-tools/misc/hold_button.gd
@@ -35,10 +35,7 @@ func is_xr_class(xr_name:  String) -> bool:
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	material = $Visualise.get_surface_override_material(0)
-	xr_start_node = XRTools.find_xr_child(
-	XRTools.find_xr_ancestor(self,
-	"*Staging",
-	"XRToolsStaging"),"StartXR","Node")
+	xr_start_node = XRToolsStartXR.get_start_xr_node()
 
 	if !Engine.is_editor_hint():
 		_set_time_held(0.0)

--- a/addons/godot-xr-tools/xr/start_xr.gd
+++ b/addons/godot-xr-tools/xr/start_xr.gd
@@ -28,9 +28,11 @@ signal xr_ended
 signal xr_failed_to_initialize
 
 
-## XR active flag
+# XR active flag
 static var _xr_active : bool = false
 
+# Keep track of instances of this class.
+static var _start_xr_nodes: Array[XRToolsStartXR]
 
 ## Optional viewport to control
 @export var viewport : Viewport
@@ -58,10 +60,32 @@ var xr_frame_rate : float = 0
 var _webxr_session_query : bool = false
 
 
+## Get our start xr node
+static func get_start_xr_node() -> XRToolsStartXR:
+	if _start_xr_nodes.is_empty():
+		push_warning("No StartXR node has been added to the scene tree.")
+		return null
+
+	# There should be only one!
+	return _start_xr_nodes[0]
+
+
+# Called when we are added to the scene tree
+func _enter_tree():
+	_start_xr_nodes.push_back(self)
+	if _start_xr_nodes.size() > 1:
+		push_warning("More than one StartXR node has been instanced!")
+
+
 # Handle auto-initialization when ready
 func _ready() -> void:
 	if !Engine.is_editor_hint():
 		_initialize()
+
+
+# Called when we are removed from the scene tree
+func _exit_tree():
+	_start_xr_nodes.erase(self)
 
 
 ## Initialize the XR interface

--- a/scenes/pickable_demo/pickable_demo.tscn
+++ b/scenes/pickable_demo/pickable_demo.tscn
@@ -117,24 +117,6 @@ transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 
 
 [node name="Skeleton3D" parent="XROrigin3D/LeftHand/XRToolsCollisionHand/LeftHand/Hand_Nails_low_L/Armature" index="0"]
 bones/1/rotation = Quaternion(0.323537, -2.56581e-05, -0.0272204, 0.945824)
-bones/2/rotation = Quaternion(-0.0904441, -0.0415175, -0.166293, 0.981042)
-bones/3/rotation = Quaternion(-0.0466199, 0.020971, 0.0103276, 0.998639)
-bones/5/rotation = Quaternion(-0.00128455, -0.0116081, -0.0168259, 0.99979)
-bones/6/rotation = Quaternion(0.102925, -0.00993208, -0.00794417, 0.994608)
-bones/7/rotation = Quaternion(-0.012859, -0.0236108, -0.323258, 0.945929)
-bones/8/rotation = Quaternion(0.0120575, -0.00929194, -0.247472, 0.968775)
-bones/10/rotation = Quaternion(-0.0357539, -0.000400032, 0.00636764, 0.99934)
-bones/11/rotation = Quaternion(-0.00264964, -0.00114471, -0.125992, 0.992027)
-bones/12/rotation = Quaternion(0.0394225, 0.00193393, -0.228074, 0.972843)
-bones/13/rotation = Quaternion(-0.0123395, -0.00881294, -0.280669, 0.959685)
-bones/15/rotation = Quaternion(-0.0702656, 0.0101908, -0.0243307, 0.99718)
-bones/16/rotation = Quaternion(-0.0320634, -0.00223624, -0.0686366, 0.997124)
-bones/17/rotation = Quaternion(0.0253452, 0.00812462, -0.249005, 0.968136)
-bones/18/rotation = Quaternion(0.00252232, 0.00788073, -0.243204, 0.96994)
-bones/20/rotation = Quaternion(-0.0917369, 0.0203027, -0.010183, 0.995524)
-bones/21/rotation = Quaternion(-0.0625182, -0.00022572, -0.115393, 0.991351)
-bones/22/rotation = Quaternion(0.0585786, 0.0216483, -0.269905, 0.96086)
-bones/23/rotation = Quaternion(0.00687177, -0.00357275, -0.211953, 0.977249)
 
 [node name="BoneAttachment3D" type="BoneAttachment3D" parent="XROrigin3D/LeftHand/XRToolsCollisionHand/LeftHand/Hand_Nails_low_L/Armature/Skeleton3D" index="1"]
 transform = Transform3D(0.54083, 0.840813, -0.0231736, -0.0826267, 0.0805243, 0.993322, 0.837064, -0.535303, 0.113023, 0.039902, 0.0402828, -0.150096)
@@ -184,24 +166,6 @@ transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 
 
 [node name="Skeleton3D" parent="XROrigin3D/RightHand/XRToolsCollisionHand/RightHand/Hand_Nails_R/Armature" index="0"]
 bones/1/rotation = Quaternion(0.323537, 2.56581e-05, 0.0272204, 0.945824)
-bones/2/rotation = Quaternion(-0.0904441, 0.0415175, 0.166293, 0.981042)
-bones/3/rotation = Quaternion(-0.0466199, -0.020971, -0.0103276, 0.998639)
-bones/5/rotation = Quaternion(-0.00128455, 0.0116081, 0.0168259, 0.99979)
-bones/6/rotation = Quaternion(0.102925, 0.00993208, 0.00794419, 0.994608)
-bones/7/rotation = Quaternion(-0.012859, 0.0236108, 0.323258, 0.945929)
-bones/8/rotation = Quaternion(0.0120575, 0.00929193, 0.247472, 0.968775)
-bones/10/rotation = Quaternion(-0.0357539, 0.000400032, -0.00636763, 0.99934)
-bones/11/rotation = Quaternion(-0.00264964, 0.00114471, 0.125992, 0.992027)
-bones/12/rotation = Quaternion(0.0394225, -0.00193393, 0.228074, 0.972843)
-bones/13/rotation = Quaternion(-0.0123395, 0.00881294, 0.280669, 0.959685)
-bones/15/rotation = Quaternion(-0.0702656, -0.0101908, 0.0243307, 0.99718)
-bones/16/rotation = Quaternion(-0.0320634, 0.00223624, 0.0686366, 0.997124)
-bones/17/rotation = Quaternion(0.0253452, -0.00812462, 0.249005, 0.968136)
-bones/18/rotation = Quaternion(0.00252233, -0.00788073, 0.243204, 0.96994)
-bones/20/rotation = Quaternion(-0.0917369, -0.0203027, 0.010183, 0.995524)
-bones/21/rotation = Quaternion(-0.0625182, 0.000225721, 0.115393, 0.991351)
-bones/22/rotation = Quaternion(0.0585786, -0.0216483, 0.269905, 0.96086)
-bones/23/rotation = Quaternion(0.00687177, 0.00357275, 0.211953, 0.977249)
 
 [node name="BoneAttachment3D" type="BoneAttachment3D" parent="XROrigin3D/RightHand/XRToolsCollisionHand/RightHand/Hand_Nails_R/Armature/Skeleton3D" index="1"]
 transform = Transform3D(0.540829, -0.840813, 0.0231736, 0.0826268, 0.0805242, 0.993322, -0.837064, -0.535303, 0.113024, -0.039902, 0.0402828, -0.150096)


### PR DESCRIPTION
Various functions were dependent on the staging system being used, even though the staging system is optional.
This PR ensures these functions are also usable when staging is not used and the StartXR node is added to a more generic setup.