### PR TITLE
Change physics_movement() return type to bool

### DIFF
--- a/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_crouch.gd
@@ -51,10 +51,10 @@ func physics_movement(
 		_delta: float,
 		player_body: XRToolsPlayerBody,
 		_disabled: bool,
-) -> void:
+) -> bool:
 	# Skip if the controller isn't active
 	if not player_body.enabled or xr_start_node.is_xr_active():
-		return
+		return false
 
 	# Detect crouch button down and pressed states
 	var crouch_button_down := Input.is_action_pressed(crouch_button_action)
@@ -81,3 +81,5 @@ func physics_movement(
 			player_body.override_player_height(self, crouch_height)
 		else:
 			player_body.override_player_height(self)
+
+	return false

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_direct.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_direct.gd
@@ -58,10 +58,10 @@ func physics_movement(
 		_delta: float,
 		player_body: XRToolsPlayerBody,
 		_disabled: bool,
-) -> void:
+) -> bool:
 	# Skip if the controller isn't active
 	if not player_body.enabled or xr_start_node.is_xr_active():
-		return
+		return false
 
 	# Calculate input vector
 	var input_dir = Input.get_vector(
@@ -82,3 +82,5 @@ func physics_movement(
 	var length := player_body.ground_control_velocity.length()
 	if length > max_speed:
 		player_body.ground_control_velocity *= max_speed / length
+
+	return false

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_flight.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_flight.gd
@@ -99,7 +99,7 @@ func physics_movement(
 		delta: float,
 		player_body: XRToolsPlayerBody,
 		disabled: bool,
-) -> void:
+) -> bool:
 	# Disable flying if requested, or if no controller
 	if (
 			disabled
@@ -108,7 +108,7 @@ func physics_movement(
 			or xr_start_node.is_xr_active()
 	):
 		set_flying(false)
-		return
+		return false
 
 	# Detect press of flight button
 	var old_flight_button: bool = _flight_button
@@ -120,7 +120,7 @@ func physics_movement(
 
 	# Skip if not flying
 	if not is_active:
-		return
+		return false
 
 	# Select the pitch vector as the vertical part of the 'head' forwards vector
 	var pitch_vector: Vector3 = -_camera.transform.basis.z.y * player_body.up_player
@@ -158,11 +158,11 @@ func physics_movement(
 	# If exclusive then perform the exclusive move-and-slide
 	if exclusive:
 		player_body.velocity = player_body.move_player(flight_velocity)
-		return
+		return true
 
 	# Update velocity and return for additional effects
 	player_body.velocity = flight_velocity
-	return
+	return false
 
 
 func set_flying(active: bool) -> void:

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_jump.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_jump.gd
@@ -33,11 +33,13 @@ func physics_movement(
 		_delta: float,
 		player_body: XRToolsPlayerBody,
 		_disabled: bool,
-) -> void:
+) -> bool:
 	# Skip if the jump controller isn't active
 	if not player_body.enabled or xr_start_node.is_xr_active():
-		return
+		return false
 
 	# Request jump if the button is pressed
 	if Input.is_action_pressed(jump_button_action):
 		player_body.request_jump()
+
+	return false

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_sprint.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_sprint.gd
@@ -63,7 +63,7 @@ func physics_movement(
 		_delta: float,
 		player_body: XRToolsPlayerBody,
 		disabled: bool,
-) -> void:
+) -> bool:
 	# Skip if the controller isn't active or is not enabled
 	if (
 			not player_body.enabled
@@ -72,7 +72,7 @@ func physics_movement(
 			or not enabled
 	):
 		set_sprinting(false)
-		return
+		return false
 
 	# Detect sprint button down and pressed states
 	var sprint_button_down := Input.is_action_pressed(sprint_button)
@@ -94,6 +94,8 @@ func physics_movement(
 	# Update sprinting state
 	if sprinting != is_active:
 		set_sprinting(sprinting)
+
+	return false
 
 
 ## Toggles sprinting

--- a/addons/godot-xr-tools/desktop-support/movement_desktop_turn.gd
+++ b/addons/godot-xr-tools/desktop-support/movement_desktop_turn.gd
@@ -106,13 +106,13 @@ func physics_movement(
 		delta: float,
 		player_body: XRToolsPlayerBody,
 		_disabled: bool
-) -> void:
+) -> bool:
 	# Skip if the player body isn't active
 	plr_body = player_body
 	if not player_body.enabled or xr_start_node.is_xr_active():
 		if clear_mouse_move_when_body_not_active:
 			mouse_move_vector = Vector2.ZERO
-		return
+		return false
 
 	# Read the left/right joystick axis to handle smooth rotation
 	var deadzone: float = 0.1
@@ -129,7 +129,8 @@ func physics_movement(
 			89.999,
 	)
 	mouse_move_vector = Vector2.ZERO
-	return
+
+	return false
 
 
 # Test if snap turning should be used

--- a/addons/godot-xr-tools/examples/fall_damage.gd
+++ b/addons/godot-xr-tools/examples/fall_damage.gd
@@ -64,11 +64,11 @@ func physics_movement(
 		_delta: float,
 		player_body: XRToolsPlayerBody,
 		disabled: bool,
-) -> void:
+) -> bool:
 	# Skip if not enabled
 	if disabled or not enabled:
 		_previous_velocity = player_body.velocity
-		return
+		return false
 
 	# Calculate the instantaneous acceleration
 	var accel_vec := player_body.velocity - _previous_velocity
@@ -84,7 +84,7 @@ func physics_movement(
 	if ground_only:
 		# Ignore if not on ground
 		if not player_body.on_ground:
-			return
+			return false
 
 		# Only consider vertical acceleration
 		accel_vec *= Vector3.UP
@@ -93,3 +93,5 @@ func physics_movement(
 	var accel := accel_vec.length()
 	if accel > damage_threshold:
 		player_fall_damage.emit(accel)
+
+	return false


### PR DESCRIPTION
Back when I made the cleanup PRs for the Desktop Movement Providers (#771, #772, #773, #779, #780, #782), I incorrectly assumed that the return type for `physics_movement()` was supposed to be `void`, since they would always return a null value. Looking at the `XRToolsPlayerBody` class properly and talking with Bastiaan Olij on Discord, it seems that it's actually supposed to be `bool`, so I made the correct changes before 4.6.0 is released.
# Note
This is a **breaking** change! I had to add `return false` statements at the end of some of these methods, so some stuff may break!