### PR TITLE
Add grip rotation override

### DIFF
--- a/addons/godot-xr-tools/plugin.gd
+++ b/addons/godot-xr-tools/plugin.gd
@@ -137,6 +137,24 @@ func _enter_tree():
 			"1.0,2.5,0.05",
 			1.85)
 
+	# Add an toggle for overriding grip rotation
+	_define_project_setting(
+			"godot_xr_tools/input/grip_rotation_override",
+			TYPE_BOOL,
+			PROPERTY_HINT_NONE,
+			"",
+			false,
+	)
+
+	# Add a grip rotation override
+	_define_project_setting(
+			"godot_xr_tools/input/overridden_grip_rotation",
+			TYPE_FLOAT,
+			PROPERTY_HINT_RANGE,
+			"%f,%f,%f,degrees" % [-90.0, 0.0, 5.0],
+			-45.0,
+	)
+
 	# Register our autoload user settings object
 	add_autoload_singleton(
 			"XRToolsUserSettings",

--- a/addons/godot-xr-tools/xr_tools.gd
+++ b/addons/godot-xr-tools/xr_tools.gd
@@ -311,7 +311,11 @@ static func is_xr_class(node : Node, type : String) -> bool:
 ## Note that this is a guestimate and that in theory rotations
 ## can vary between runtimes.
 static func get_grip_rotation(profile : String) -> float:
-	# TODO add in a way for users to override this through a setting.
+	if not ProjectSettings.get_setting("godot_xr_tools/input/grip_rotation_override"):
+		return deg_to_rad(ProjectSettings.get_setting(
+				"godot_xr_tools/input/overriden_grip_rotation"
+		))
+
 	if grip_rotations.has(profile):
 		return grip_rotations[profile]
 


### PR DESCRIPTION
Adds two new Project Settings
- Toggle for overriding grip rotation
- What the override for the grip rotation should be (default is -45 degrees)
# Testing
Adding the plugin to a fresh new project contained no issues not present in `master`.
# Disclaimer
No generative AI was used to enhance or create the code given here.